### PR TITLE
Improve example by also setting the lang attribute

### DIFF
--- a/examples/sveltekit/src/app.html
+++ b/examples/sveltekit/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="%sveltekit.lang%">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/examples/sveltekit/src/hooks.server.ts
+++ b/examples/sveltekit/src/hooks.server.ts
@@ -11,5 +11,12 @@ export const handle: Handle = async ({ event, resolve }) => {
         return await resolve(event)
     }
     const catalog = await import(`./locales/${locale}.svelte.js`)
-    return await runWithCatalog(catalog, async () => await resolve(event))
+    return await runWithCatalog(catalog, async () => await resolve(event, {
+		transformPageChunk: ({ html }) => {
+			if (html.includes('%sveltekit.lang%')) {
+				return html.replace('%sveltekit.lang%', locale);
+			}
+			return html;
+		}
+	});)
 }


### PR DESCRIPTION
I noticed on `paraglide.js`'s documentation that you need to also set the `lang` attribute within the html. Now, the thing is usually the lang attribute relies on `BCP 47` syntax instead of `ISO 639` but at least with this package, that doesn't matter because locales are just strings.

The neat part is we can simply pass on the local to the event resolve transformer and replace the `%sveltekit.lang%` attribute with the selected locale. The check could be better tbh, using `includes` is a bit too broad but for an example I think it's pretty neat.