### PR TITLE
Add Go adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ rnd
 packages/*/tests/test-tmp/
 dist
 **/*.tsbuildinfo
+packages/go/main

--- a/packages/go/go.mod
+++ b/packages/go/go.mod
@@ -1,0 +1,3 @@
+module adapter
+
+go 1.24.6

--- a/packages/go/package.json
+++ b/packages/go/package.json
@@ -1,0 +1,59 @@
+{
+    "name": "@wuchale/go",
+    "version": "0.1.0",
+    "description": "Protobuf-like i18n from plain code: Golang adapter",
+    "scripts": {
+        "dev": "tsc --watch",
+        "build": "tsc",
+        "test": "go build src/main.go && ./main tests/test.go"
+    },
+    "keywords": [
+        "i18n",
+        "internationalization",
+        "translation",
+        "gettext",
+        "golang",
+        "go",
+        "vite",
+        "po",
+        "go-i18n",
+        "golang-i18n",
+        "vite-plugin",
+        "compile-time",
+        "ast",
+        "gemini",
+        "translation-tooling",
+        "multilingual",
+        "localization",
+        "l10n",
+        "lingui",
+        "automatic-i18n",
+        "lightweight"
+    ],
+    "files": [
+    ],
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        },
+        "./runtime.svelte": "./src/runtime.svelte"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/wuchalejs/wuchale.git"
+    },
+    "homepage": "https://wuchale.dev",
+    "bugs": "https://github.com/wuchalejs/wuchale/issues",
+    "author": "K1DV5",
+    "license": "MIT",
+    "dependencies": {
+        "svelte": "^5.37.0",
+        "wuchale": "^0.17.1"
+    },
+    "devDependencies": {
+        "acorn": "^8.15.0",
+        "typescript": "^5.9.3"
+    },
+    "type": "module"
+}

--- a/packages/go/src/main.go
+++ b/packages/go/src/main.go
@@ -1,0 +1,34 @@
+// $ cd .. && npm run test
+
+package main
+
+import (
+	"fmt"
+	"go/parser"
+	"go/token"
+	"go/ast"
+	"os"
+)
+
+func main() {
+	if len(os.Args) == 1 {
+		fmt.Println("File required")
+		return
+	}
+	filename := os.Args[1]
+	fs := token.NewFileSet()
+	node, err := parser.ParseFile(fs, filename, nil, parser.ParseComments)
+	if err != nil {
+		fmt.Println("error", err)
+	}
+	for _, decl := range node.Decls {
+		switch d := decl.(type) {
+		case *ast.GenDecl:
+			fmt.Println("general", d)
+		case *ast.FuncDecl:
+			fmt.Println("func", d)
+		default:
+			fmt.Println("def", d)
+		}
+	}
+}

--- a/packages/go/tests/test.go
+++ b/packages/go/tests/test.go
@@ -1,0 +1,15 @@
+package tests
+
+import (
+	"fmt"
+)
+
+func foo() string {
+	x := "Hello"
+	fmt.Println("Hello")
+	return x
+}
+
+func main() {
+	fmt.Println(foo())
+}


### PR DESCRIPTION
This will add an extract-only Go adapter that doesn't do any transformation but just extracts the strings. The user has to then use the strings as keys for the generated catalogs. They will of course be big as they contain the source and target messages, but that will not be a big problem because the catalogs stay on the server.