### PR TITLE
Narrow `locales` array type to actual locales

### DIFF
--- a/packages/wuchale/src/handler/files.ts
+++ b/packages/wuchale/src/handler/files.ts
@@ -199,7 +199,7 @@ export class Files {
             resolve(this.#localesDir, dataFileName),
             [
                 `export const sourceLocale = '${sourceLocale}'`,
-                `/** @type {('${locales.join("','")}')[]} */`,
+                `/** @type {('${locales.join("'|'")}')[]} */`,
                 `export const locales = ['${locales.join("','")}']`,
             ].join('\n'),
         )


### PR DESCRIPTION
Added JSDoc type annotation for the `locales` array. When using TypeScript, the `locales` array will now be typed as the valid locales, instead of just `string[]`.