### PR TITLE
vite-plugin: ignore non-cache query IDs during transform matching

### DIFF
--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -215,12 +215,14 @@ export class Wuchale {
         let filename = relative(this.#projectRoot, id)
         const queryIndex = filename.indexOf('?')
         if (queryIndex >= 0) {
-            const query = new URLSearchParams(filename.slice(queryIndex))
-            if (query.size === 1 && query.has('v')) {
-                // trim after this, like ?v=b65b2c3b when it's from node_modules
+            const query = new URLSearchParams(filename.slice(queryIndex + 1))
+            // Only trim cache-busting queries. Keep other virtual-module queries intact
+            // so fileMatches() does not route style/template sub-modules to wuchale.
+            if (query.size === 1 && (query.has('v') || query.has('t'))) {
                 filename = filename.slice(0, queryIndex)
             }
         }
+        filename = normalizeSep(filename)
         for (const adapter of this.#adapters.values()) {
             if (adapter.fileMatches(filename)) {
                 try {


### PR DESCRIPTION
## Problem
Vite provides multiple kinds of query IDs. Some are cache-busting (`?v=...`, `?t=...`), while others identify virtual submodules (for example `?svelte&type=style&lang.css`).

If we strip every query blindly, virtual submodule IDs can be treated like normal source files and routed into wuchale adapter matching. That is a problem because these IDs are not transform targets for message extraction, and it can cause:
- false adapter matches for non-source submodules
- incorrect transforms on virtual/style fragments
- unnecessary module invalidation or reload behavior

## Fix
- parse query IDs in `#transformHandler`
- strip only cache-busting single-key queries (`v` and `t`)
- keep other query IDs intact so virtual/style submodule IDs are ignored by adapter matching

## Verification
In a clean worktree at this PR head:
- `node --import ../wuchale/testing/resolve.ts --test src/index.test.ts`
- result: `6 passed, 0 failed`