### PR TITLE
B1: prevent deep merge from mutating shared defaults

### DIFF
--- a/packages/wuchale/src/config.test.ts
+++ b/packages/wuchale/src/config.test.ts
@@ -1,0 +1,32 @@
+// $ node --import ../testing/resolve.ts %f
+
+import { type TestContext, test } from 'node:test'
+import { deepMergeObjects, defaultConfig } from './config.js'
+
+test('Deep merge does not mutate nested defaults', (t: TestContext) => {
+    const defaults = {
+        runtime: {
+            plain: {
+                wrapInit: 'plain',
+            },
+        },
+    }
+    const custom = deepMergeObjects(
+        {
+            runtime: {
+                plain: {
+                    wrapInit: 'custom',
+                },
+            },
+        },
+        defaults,
+    )
+
+    t.assert.equal(custom.runtime.plain.wrapInit, 'custom')
+    t.assert.equal(defaults.runtime.plain.wrapInit, 'plain')
+    t.assert.equal(deepMergeObjects({}, defaults).runtime.plain.wrapInit, 'plain')
+
+    deepMergeObjects({ fallback: { es: 'en' } }, defaultConfig)
+    t.assert.deepEqual(defaultConfig.fallback, {})
+    t.assert.deepEqual(deepMergeObjects({}, defaultConfig).fallback, {})
+})

--- a/packages/wuchale/src/config.ts
+++ b/packages/wuchale/src/config.ts
@@ -29,6 +29,20 @@ export const defaultConfig: Config = {
     logLevel: 'info',
 }
 
+function cloneValue<Value>(value: Value): Value {
+    if (!value || typeof value !== 'object') {
+        return value
+    }
+    if (Array.isArray(value)) {
+        return value.map(item => cloneValue(item)) as Value
+    }
+    const cloned = {} as Record<string, unknown>
+    for (const [key, item] of Object.entries(value)) {
+        cloned[key] = cloneValue(item)
+    }
+    return cloned as Value
+}
+
 function deepAssign<Type extends {}>(fromObj: Partial<Type>, toObj: Type) {
     for (const [key, value] of Object.entries(fromObj)) {
         if (value === undefined) {
@@ -36,7 +50,7 @@ function deepAssign<Type extends {}>(fromObj: Partial<Type>, toObj: Type) {
             continue
         }
         if (!value || Array.isArray(value) || typeof value !== 'object') {
-            toObj[key] = value
+            toObj[key] = cloneValue(value)
             continue
         }
         // value is an object. force prepare an object on the destination
@@ -52,7 +66,7 @@ export function defineConfig(config: ConfigWithOptional) {
 }
 
 export function deepMergeObjects<Type extends {}>(source: Partial<Type>, target: Type): Type {
-    const full = { ...target }
+    const full = cloneValue(target)
     deepAssign(source, full)
     return full
 }


### PR DESCRIPTION
## Bug Explanation (B1)

This is a shared-mutable-defaults bug caused by object identity leakage in `deepMergeObjects()`.

The original merge flow started with a shallow clone:

```ts
const full = { ...target }
```

That only cloned the top level. Nested branches (`runtime`, `fallback`, adapter runtime config, etc.) still referenced the same objects from `target`. Then `deepAssign()` recursively mutated those nested objects in place, so a "merged" call could silently mutate shared defaults.

In practice this made defaults order-dependent in long-lived processes:
- one call that customizes a nested branch could mutate defaults
- later calls that requested defaults could inherit earlier customizations

This affected any nested default config that went through this helper (global config and adapter-level defaults).

## Fix

Keep merge results fully detached from defaults:
- add recursive `cloneValue()`
- start merges from `cloneValue(target)` instead of `{ ...target }`
- when assigning values during merge, assign `cloneValue(value)`

So merged outputs no longer share nested references with defaults.

## Regression

Added `packages/wuchale/src/config.test.ts`:
- `Deep merge does not mutate nested defaults`

## Test

- `node --import ./testing/resolve.ts --test ./src/config.test.ts`
