### PR TITLE
B2: clear stale catalog/manifest state on reload and recompile

### DIFF
--- a/packages/wuchale/src/handler/index.test.ts
+++ b/packages/wuchale/src/handler/index.test.ts
@@ -8,6 +8,7 @@ import { defaultArgs } from '../adapter-vanilla/index.js'
 import { type Adapter, newMessage } from '../adapters.js'
 import { defaultConfig } from '../config.js'
 import { Logger } from '../log.js'
+import { defaultPluralRule, newItem, type Item, type SaveData } from '../storage.js'
 import { generatedDir } from './files.js'
 import { AdapterHandler } from './index.js'
 import { SharedState } from './state.js'
@@ -41,6 +42,8 @@ const storage = inMemStorage({
 
 // needed to make sure generatedDir exists, normally done at hub init
 await handler.init(new SharedState(storage, handler.key, 'en'))
+
+const localesDir = resolve(import.meta.dirname, '../../testing/tmp')
 
 test('HMR', async (t: TestContext) => {
     const content = ts`'Hello'`
@@ -90,4 +93,113 @@ test('Handle messages', async (t: TestContext) => {
     t.assert.strictEqual(updated1, false)
     const [, updated2] = await handler.handleMessages(msgs, 'bar.ts')
     t.assert.strictEqual(updated2, true)
+})
+
+function createTestFS() {
+    const files = new Map<string, string>()
+    return {
+        files,
+        fs: {
+            write: (file: string, data: string) => {
+                files.set(file, data)
+            },
+            read: (file: string) => files.get(file) ?? '',
+            mkdir: () => {},
+            exists: (file: string) => files.has(file),
+            unlink: (file: string) => {
+                files.delete(file)
+            },
+        },
+    }
+}
+
+function createStorage(initial: SaveData) {
+    let stored = initial
+    return {
+        storage: {
+            key: 'storage',
+            load: async () => stored,
+            save: async (data: SaveData) => {
+                stored = data
+            },
+            files: [],
+        },
+        set: (data: SaveData) => {
+            stored = data
+        },
+    }
+}
+
+function makeSaveData(items: Item[], locales = ['en', 'es']): SaveData {
+    const pluralRules = new Map(locales.map(loc => [loc, defaultPluralRule]))
+    return { items, pluralRules }
+}
+
+function makeItem(text: string, locales = ['en', 'es']): Item {
+    const item = newItem(
+        {
+            id: [text],
+            references: [{ file: 'test.js', refs: [null] }],
+        },
+        locales,
+    )
+    item.translations.set('en', [text])
+    for (const locale of locales) {
+        if (locale !== 'en') {
+            item.translations.set(locale, [])
+        }
+    }
+    return item
+}
+
+async function createTestHandler(
+    data: SaveData,
+    { locales = ['en', 'es'], sourceLocale = 'en' }: { locales?: string[]; sourceLocale?: string } = {},
+) {
+    const testFS = createTestFS()
+    const storage = createStorage(data)
+    const testHandler = new AdapterHandler(
+        { ...adapter, sourceLocale },
+        'test',
+        { ...defaultConfig, locales, localesDir },
+        'dev',
+        testFS.fs,
+        import.meta.dirname,
+        new Logger('error'),
+    )
+    await testHandler.init(new SharedState(storage.storage, testHandler.key, sourceLocale))
+    return { handler: testHandler, storage, files: testFS.files }
+}
+
+test('Compile clears removed items from catalogs and manifests', async (t: TestContext) => {
+    const hello = makeItem('Hello')
+    const bye = makeItem('Bye')
+    const { handler, files } = await createTestHandler(makeSaveData([hello, bye]))
+
+    handler.sharedState.catalog.delete('Bye')
+    await handler.compile()
+
+    const compiledPath = resolve(localesDir, generatedDir, 'test.test.en.compiled.js')
+    const manifestPath = resolve(localesDir, generatedDir, 'test.test.manifest.js')
+    const compiled = trimLines(files.get(compiledPath)) ?? ''
+    t.assert.strictEqual(compiled.includes('export let c = ["Hello"]'), true)
+    t.assert.strictEqual(compiled.includes('Bye'), false)
+    t.assert.strictEqual(
+        trimLines(files.get(manifestPath)),
+        trimLines(
+            `/** @type {(string | {text: string | string[], context?: string, isUrl?: boolean} | null)[]} */
+export const keys = ["Hello",null]`,
+        ),
+    )
+})
+
+test('Load clears removed storage items', async (t: TestContext) => {
+    const hello = makeItem('Hello', ['en'])
+    const bye = makeItem('Bye', ['en'])
+    const { handler, storage } = await createTestHandler(makeSaveData([hello, bye], ['en']), { locales: ['en'] })
+
+    storage.set(makeSaveData([hello], ['en']))
+    await handler.loadStorage()
+
+    t.assert.deepStrictEqual([...handler.sharedState.catalog.keys()], ['Hello'])
 })

--- a/packages/wuchale/src/handler/index.ts
+++ b/packages/wuchale/src/handler/index.ts
@@ -11,7 +11,7 @@ import type { FS } from '../fs.js'
 import type { Logger } from '../log.js'
 import { type FileRef, type FileRefEntry, type Item, itemIsUrl, newItem } from '../storage.js'
 import { Files, globConfToArgs, type ManifestEntry, normalizeSep, objKeyLocale } from './files.js'
-import { type SharedState, State } from './state.js'
+import { type Compiled, type SharedState, State } from './state.js'
 import { URLHandler } from './url.js'
 
 const loaderImportGetRuntime = 'getRuntime'
@@ -131,9 +131,10 @@ export class AdapterHandler {
     }
 
     compile = async (hmrVersion = -1) => {
-        // for proper fallback
-        const localesOrdered = [this.sourceLocale, ...this.#config.locales.filter(l => l !== this.sourceLocale)]
-        await Promise.all(localesOrdered.map(loc => this.#compileForLocale(loc, hmrVersion)))
+        const locales = [this.sourceLocale, ...this.#config.locales.filter(loc => loc !== this.sourceLocale)]
+        for (const loc of locales) {
+            await this.#compileForLocale(loc, hmrVersion)
+        }
         await this.#writeManifests()
     }
 
@@ -142,7 +143,7 @@ export class AdapterHandler {
         for (const [key, index] of indices) {
             const item = this.sharedState.catalog.get(key)
             if (item === undefined) {
-                manifest[index] = { text: key, isUrl: true }
+                manifest[index] = null
                 continue
             }
 
@@ -219,8 +220,8 @@ export class AdapterHandler {
                     fallbackLoc = this.sourceLocale
                 }
             }
-            const catalog = this.sharedState.compiled.get(fallbackLoc)?.items!
-            const compiled = catalog[index]
+            const catalog = this.sharedState.compiled.get(fallbackLoc)?.items
+            const compiled = catalog?.[index]
             if (compiled || fallbackLoc === this.sourceLocale) {
                 // last try
                 return compiled || ''
@@ -231,11 +232,8 @@ export class AdapterHandler {
     }
 
     #compileForLocale = async (loc: string, hmrVersion = -1) => {
-        let sharedCompiledLoc = this.sharedState.compiled.get(loc)
-        if (sharedCompiledLoc == null) {
-            sharedCompiledLoc = { hasPlurals: false, items: [] }
-            this.sharedState.compiled.set(loc, sharedCompiledLoc)
-        }
+        const sharedCompiledLoc: Compiled = { hasPlurals: false, items: [] }
+        const granularCompiled: Map<string, Compiled> = new Map()
         for (const [itemKey, item] of this.sharedState.catalog) {
             // compile only if it came from a file under this adapter
             // for urls, skip if not referenced in links
@@ -277,10 +275,22 @@ export class AdapterHandler {
                 }
                 for (const ref of item.references) {
                     const state = await this.granularState.byFileCreate(ref.file, this.#config.locales)
-                    const compiledLoc = state.compiled.get(loc)!
-                    compiledLoc.hasPlurals = sharedCompiledLoc.hasPlurals
+                    let compiledLoc = granularCompiled.get(state.id)
+                    if (compiledLoc == null) {
+                        compiledLoc = { hasPlurals: false, items: [] }
+                        granularCompiled.set(state.id, compiledLoc)
+                    }
+                    if (transl.length > 1) {
+                        compiledLoc.hasPlurals = true
+                    }
                     compiledLoc.items[state.indexTracker.get(key)] = compiled
                 }
+            }
+        }
+        this.sharedState.compiled.set(loc, sharedCompiledLoc)
+        if (this.adapter.granularLoad) {
+            for (const state of this.granularState.byID.values()) {
+                state.compiled.set(loc, granularCompiled.get(state.id) ?? { hasPlurals: false, items: [] })
             }
         }
         await this.writeCompiled(loc, hmrVersion)

--- a/packages/wuchale/src/handler/state.ts
+++ b/packages/wuchale/src/handler/state.ts
@@ -50,6 +50,7 @@ export class SharedState {
     }
 
     async load(locales: string[]) {
+        this.catalog.clear()
         const loaded = await this.storage.load()
         this.pluralRules = loaded.pluralRules ?? new Map()
         for (const loc of locales) {


### PR DESCRIPTION
## Bug Explanation (B2)

This was a stale in-memory lifecycle bug that mainly appears in long-lived processes (dev server/watch), not clean restarts.

There were three stale-state layers:

1. `SharedState.load()` merged loaded items into existing in-memory catalog state instead of replacing it.
   - deleted/renamed PO entries could stay alive in memory
2. Compile reused previously allocated compiled arrays and only overwrote visited indexes.
   - deleted entries could survive in compiled catalogs
3. Manifest generation emitted synthetic entries for deleted keys:

```ts
manifest[index] = { text: key, isUrl: true }
```

   - deleted keys appeared as ghost entries instead of being represented as removed

Because this all happened in-process, storage on disk and runtime state could drift apart until restart.

## Fix

- clear catalog before reload (`this.catalog.clear()`)
- compile locales sequentially with source locale first for stable fallback reads
- rebuild per-locale compiled outputs from scratch and swap them in
  - both shared compiled catalogs and granular compiled catalogs are replaced per compile
- represent deleted manifest slots as `null` instead of synthetic URL entries
- add guards in fallback reads to avoid indexing missing compiled arrays during rebuild

Result: reload/compile now replaces current state from storage/catalog instead of mutating stale structures.

## Regression

Updated `packages/wuchale/src/handler/index.test.ts` with:
- `Compile clears removed items from catalogs and manifests`
- `Load clears removed storage items`

## Test

- `npx tsc -p packages/wuchale/tsconfig.build.json --checkJs false --allowJs false`
- `node --import ./testing/resolve.ts --test ./src/handler/index.test.ts`
