### PR TITLE
C12: make default granular load IDs collision-safe

### DIFF
--- a/packages/wuchale/src/adapters.test.ts
+++ b/packages/wuchale/src/adapters.test.ts
@@ -1,0 +1,12 @@
+// $ node --import ../testing/resolve.ts %f
+
+import { test } from 'node:test'
+import { defaultGenerateLoadID } from './adapters.js'
+
+test('defaultGenerateLoadID avoids separator collisions', t => {
+    const direct = defaultGenerateLoadID('src/foo-bar.js')
+    const nested = defaultGenerateLoadID('src/foo/bar.js')
+    t.assert.notStrictEqual(direct, nested)
+    t.assert.match(direct, /^[A-Za-z0-9_]+$/)
+    t.assert.match(nested, /^[A-Za-z0-9_]+$/)
+})

--- a/packages/wuchale/src/adapters.ts
+++ b/packages/wuchale/src/adapters.ts
@@ -147,7 +147,8 @@ export const defaultHeuristicFuncOnly: HeuristicFunc = msg => {
     return false
 }
 
-export const defaultGenerateLoadID = (filename: string) => filename.replace(/[^a-zA-Z0-9_]+/g, '_')
+export const defaultGenerateLoadID = (filename: string) =>
+    filename.replace(/[^a-zA-Z0-9]/g, c => `_${c.codePointAt(0)!.toString(16)}_`)
 
 export class IndexTracker {
     indices: Map<string, number> = new Map()


### PR DESCRIPTION
## Bug Explanation (C12)

This was an identity/collision bug in the default granular load-ID generator.

Old behavior:

```ts
filename.replace(/[^a-zA-Z0-9_]+/g, '_')
```

That mapping is non-injective: different filenames can collapse to the same load ID (for example `src/foo-bar.js` and `src/foo/bar.js`).

In granular mode, load ID is state identity (`State.byID`), so collisions mean different files can be treated as the same granular translation unit and share:
- compiled catalog state
- manifest/index tracker state
- runtime/proxy identity

That can mix/overwrite generated outputs across unrelated files.

## Fix

Use per-character encoding for every non-alphanumeric character:

```ts
filename.replace(/[^a-zA-Z0-9]/g, c => `_${c.codePointAt(0)!.toString(16)}_`)
```

This keeps IDs JS-safe while preserving separator distinctions (`/`, `-`, `.`), avoiding the default collision class without introducing hashing or registries.

## Regression

Added `packages/wuchale/src/adapters.test.ts`:
- `defaultGenerateLoadID avoids separator collisions`

## Test

- `npx tsc -p packages/wuchale/tsconfig.build.json --checkJs false --allowJs false`
- `node --import ./testing/resolve.ts --test ./src/adapters.test.ts`
