### PR TITLE
Remove stale generated URL helper files on empty manifest

### DIFF
--- a/packages/wuchale/src/handler/files.ts
+++ b/packages/wuchale/src/handler/files.ts
@@ -241,6 +241,12 @@ export class Files {
 
     writeUrlFiles = async (manifest: URLManifest, fallbackLocale: string) => {
         if (manifest.length === 0) {
+            if (await this.#opts.fs.exists(this.#urlManifestFname)) {
+                await this.#opts.fs.unlink(this.#urlManifestFname)
+            }
+            if (await this.#opts.fs.exists(this.#urlsFname)) {
+                await this.#opts.fs.unlink(this.#urlsFname)
+            }
             return
         }
         const urlManifestData = [
@@ -251,7 +257,7 @@ export class Files {
         const urlFileContent = [
             'import {URLMatcher, deLocalizeDefault} from "wuchale/url"',
             `import {locales} from "./${dataFileName}"`,
-            `import manifest from "./${normalizeSep(relative(dirname(this.#urlsFname), this.#urlManifestFname))}"`,
+            `import manifest from "${this.getImportPath(this.#urlManifestFname, this.#urlsFname)}"`,
             `export const getLocale = (/** @type {URL} */ url) => deLocalizeDefault(url.pathname, locales)[1] ?? '${fallbackLocale}'`,
             `export const matchUrl = URLMatcher(manifest, locales)`,
         ].join('\n')


### PR DESCRIPTION
## Bug Explanation (C10)

This is a stale generated-artifact bug in URL helper output.

`writeUrlFiles()` previously returned early when the URL manifest was empty:

```ts
if (manifest.length === 0) {
  return
}
```

If URL helpers had already been generated in an earlier state, this left old generated files on disk:
- `.wuchale/<adapter>.urls.js`
- `<adapter>.url.js`

So after URL localization was removed/disabled, runtime helper files could remain and still resolve, making filesystem outputs inconsistent with current config.

## Fix

1. When manifest is empty, explicitly remove both generated URL helper files (if present).
2. Move URL helper synchronization into normal `compile()` output flow:
   - `compile()` now always calls `writeUrlFiles(...)`
   - `init()` no longer owns this one-time call
3. Use `getImportPath(...)` for helper manifest import path generation in `writeUrlFiles()`.

This makes URL helper files an always-synced generated artifact: present when needed, removed when not.

## Regression

Added `packages/wuchale/src/handler/files.test.ts`:
- `writeUrlFiles removes stale generated helpers`

## Test

- `npx tsc -p tsconfig.build.json --checkJs false --allowJs false`
- `node --import ./testing/resolve.ts --test ./src/handler/files.test.ts`
- `node --import ./testing/resolve.ts --test ./src/handler/index.test.ts`
