### PR TITLE
Fix optional chaining for AI group access

### DIFF
--- a/packages/wuchale/src/ai/index.ts
+++ b/packages/wuchale/src/ai/index.ts
@@ -193,7 +193,7 @@ export default class AIQueue {
                 if (loc === this.sourceLocale || transl[0]) {
                     continue
                 }
-                const group = this.ai.group[this.sourceLocale]?.find(g => g.includes(loc))
+                const group = this.ai.group?.[this.sourceLocale]?.find(g => g.includes(loc))
                 const groupKey = group ?? loc
                 if (!itemsByLocales.has(groupKey)) {
                     itemsByLocales.set(groupKey, [])


### PR DESCRIPTION
Let the `group` property of the ai configuration be optional.

In the [docs](https://wuchale.dev/guides/ai/#other-llms), there is no `group` property in the example. It currently fails.

<img width="743" height="670" alt="image" src="https://github.com/user-attachments/assets/dd24e8e1-f863-4aa0-a2d5-5064a3fe3e63" />
