### PR TITLE
Change context check from undefined to null

### DIFF
--- a/packages/wuchale/src/handler/index.ts
+++ b/packages/wuchale/src/handler/index.ts
@@ -149,7 +149,7 @@ export class AdapterHandler {
             const isUrl = itemIsUrl(item)
             const id = item.translations.get(this.sourceLocale)!
             const text = id.length === 1 ? id[0] : id
-            if (!isUrl && item.context === undefined) {
+            if (!isUrl && item.context == null) {
                 manifest[index] = text
                 continue
             }


### PR DESCRIPTION
Before:

```ts
export const keys = [{"text":"Sign in","context":null}]
```

After:

```ts
export const keys = ["Sign in"]
```