### PR TITLE
Fix type annotations in writeManifest function

### DIFF
--- a/packages/wuchale/src/handler/files.ts
+++ b/packages/wuchale/src/handler/files.ts
@@ -264,7 +264,7 @@ export class Files {
 
     writeManifest = async (keys: ManifestEntry[], id: string | null) => {
         const content =
-            `/** @type {(string | {text: string | string[], context?: string, isUrl?: boolean} | null)[]} */\n` +
+            `/** @type {(string | string[] | {text: string | string[], context?: string, isUrl?: boolean})[]} */\n` +
             `export const keys = ${JSON.stringify(keys)}`
         await this.#fs.write(this.getManifestFilePath(id), content)
     }

--- a/packages/wuchale/src/handler/index.test.ts
+++ b/packages/wuchale/src/handler/index.test.ts
@@ -74,7 +74,7 @@ test('Manifest', async (t: TestContext) => {
     t.assert.strictEqual(
         trimLines(content),
         trimLines(
-            `/** @type {(string | {text: string | string[], context?: string, isUrl?: boolean} | null)[]} */\nexport const keys = ["Hello"]`,
+            `/** @type {(string | string[] | {text: string | string[], context?: string, isUrl?: boolean})[]} */\nexport const keys = ["Hello"]`,
         ),
     )
 })


### PR DESCRIPTION
`string`: simple message
`string[]`: pluralized message
`{text: string | string[], context?: string, isUrl?: boolean}`: message with context or URL.

I don't think `null` entries is possible.