### PR TITLE
hub,test: add regression for compile once per handler

### DIFF
--- a/packages/wuchale/src/hub.test.ts
+++ b/packages/wuchale/src/hub.test.ts
@@ -77,6 +77,58 @@ test('hub onFileChange', async (t: TestContext) => {
     )
 })
 
+test('hub onFileChange compiles once per handler for catalog changes', async (t: TestContext) => {
+    const writes: string[] = []
+    const countingFS = {
+        ...inMemFS,
+        write(file: string, data: string) {
+            writes.push(normalizeSep(resolve(file)))
+            return inMemFS.write(file, data)
+        },
+    }
+    countingFS.write(defaultLoaderPath.client, '')
+    countingFS.write(defaultLoaderPath.server, '')
+
+    const hub = await Hub.create(
+        'dev',
+        async () => ({
+            ...defaultConfig,
+            locales: ['en', 'fr'],
+            adapters: {
+                main: {
+                    ...defaultArgs,
+                    transform: dummyTransform,
+                    files: 'src/*.js',
+                    loaderExts: ['.js'],
+                    defaultLoaderPath,
+                },
+            },
+        }),
+        import.meta.dirname,
+        0,
+        countingFS,
+    )
+
+    await hub.transform(code, file)
+    writes.length = 0
+
+    const po_fname = normalizeSep(resolve(import.meta.dirname, defaultConfig.localesDir, 'fr.po'))
+    const res = await hub.onFileChange(po_fname, () => 'external catalog change')
+
+    t.assert.strictEqual(res?.sourceTriggered, false)
+
+    const compiled_writes = writes.filter(file => file.endsWith('.compiled.js'))
+
+    t.assert.strictEqual(compiled_writes.length, 2)
+    t.assert.deepStrictEqual(
+        new Set(compiled_writes),
+        new Set([
+            normalizeSep(resolve(import.meta.dirname, defaultConfig.localesDir, generatedDir, 'main.main.en.compiled.js')),
+            normalizeSep(resolve(import.meta.dirname, defaultConfig.localesDir, generatedDir, 'main.main.fr.compiled.js')),
+        ]),
+    )
+})
+
 test('hub transform with hmr', async (t: TestContext) => {
     const [output] = await hub.transform(code, file)
     t.assert.strictEqual(


### PR DESCRIPTION
## Summary

Adds regression coverage for the compile-once behavior on external catalog changes. This verifies that `hub.onFileChange()` does not compile once per locale and instead results in one handler-level compile pass (reflected by exactly one compiled write per locale output file).

Files changed:
- `packages/wuchale/src/hub.test.ts`

---
# Long Version

The behavior fix itself was implemented upstream in `a3321ba`.

This PR now focuses only on protecting that behavior with a targeted test:

- trigger `onFileChange()` with an external `.po` catalog change in a 2-locale setup
- assert `sourceTriggered === false`
- assert compiled outputs are written exactly once per locale (`en`, `fr`), not multiplied by locale-loop recompilation

This keeps the test signal focused on the original regression and prevents future reintroduction of compile fan-out.
