### PR TITLE
pofile: reduce redundant save work

### DIFF
--- a/packages/wuchale/src/pofile.test.ts
+++ b/packages/wuchale/src/pofile.test.ts
@@ -74,6 +74,66 @@ test('POFile removes stale url catalogs', async (t: TestContext) => {
     t.assert.strictEqual(await inMemFS.exists(urlPath), false)
 })
 
+test('POFile skips unlinking missing url catalogs once their absence is known', async (t: TestContext) => {
+    const root = '/projects-known-missing-url'
+    let unlinkCalls = 0
+    const fs = {
+        ...inMemFS,
+        unlink(file: string) {
+            unlinkCalls++
+            return inMemFS.unlink(file)
+        },
+    }
+    const po = new POFile({
+        dir: 'src/locales',
+        separateUrls: true,
+        locales: ['en', 'es'],
+        root,
+        haveUrl: true,
+        localesDir: 'src/locales',
+        sourceLocale: 'en',
+        fs,
+    })
+    await po.save(makeSaveData([item]))
+    const reloaded = new POFile({
+        dir: 'src/locales',
+        separateUrls: true,
+        locales: ['en', 'es'],
+        root,
+        haveUrl: true,
+        localesDir: 'src/locales',
+        sourceLocale: 'en',
+        fs,
+    })
+    await reloaded.load()
+    unlinkCalls = 0
+    await reloaded.save(makeSaveData([item]))
+    t.assert.strictEqual(unlinkCalls, 0)
+})
+
+test('POFile does not touch url catalogs when url handling is disabled', async (t: TestContext) => {
+    let unlinkCalls = 0
+    const fs = {
+        ...inMemFS,
+        unlink(file: string) {
+            unlinkCalls++
+            return inMemFS.unlink(file)
+        },
+    }
+    const po = new POFile({
+        dir: 'src/locales',
+        separateUrls: true,
+        locales: ['en', 'es'],
+        root: '/projects-no-url-support',
+        haveUrl: false,
+        localesDir: 'src/locales',
+        sourceLocale: 'en',
+        fs,
+    })
+    await po.save(makeSaveData([item]))
+    t.assert.strictEqual(unlinkCalls, 0)
+})
+
 test('pofile defaults dir to localesDir', async (t: TestContext) => {
     const storage = await pofile()({
         locales: ['en'],

--- a/packages/wuchale/src/pofile.test.ts
+++ b/packages/wuchale/src/pofile.test.ts
@@ -33,7 +33,7 @@ item.translations.set('es', ['Hola'])
 
 const root = '/projects'
 
-const po = new POFile({
+const pofileOpts = {
     dir: 'src/locales',
     separateUrls: true,
     locales: ['en', 'es'],
@@ -42,7 +42,9 @@ const po = new POFile({
     localesDir: 'src/locales',
     sourceLocale: 'en',
     fs: inMemFS,
-})
+}
+
+const po = new POFile(pofileOpts)
 
 test('POFile round-trips reference metadata', async (t: TestContext) => {
     await po.save(makeSaveData([item]))
@@ -74,8 +76,7 @@ test('POFile removes stale url catalogs', async (t: TestContext) => {
     t.assert.strictEqual(await inMemFS.exists(urlPath), false)
 })
 
-test('POFile skips unlinking missing url catalogs once their absence is known', async (t: TestContext) => {
-    const root = '/projects-known-missing-url'
+test('POFile skips unlinking non existent catalogs', async (t: TestContext) => {
     let unlinkCalls = 0
     const fs = {
         ...inMemFS,
@@ -84,53 +85,12 @@ test('POFile skips unlinking missing url catalogs once their absence is known', 
             return inMemFS.unlink(file)
         },
     }
-    const po = new POFile({
-        dir: 'src/locales',
-        separateUrls: true,
-        locales: ['en', 'es'],
-        root,
-        haveUrl: true,
-        localesDir: 'src/locales',
-        sourceLocale: 'en',
-        fs,
-    })
+    const po = new POFile({ ...pofileOpts, fs })
     await po.save(makeSaveData([item]))
-    const reloaded = new POFile({
-        dir: 'src/locales',
-        separateUrls: true,
-        locales: ['en', 'es'],
-        root,
-        haveUrl: true,
-        localesDir: 'src/locales',
-        sourceLocale: 'en',
-        fs,
-    })
+    const reloaded = new POFile({ ...pofileOpts, fs })
     await reloaded.load()
     unlinkCalls = 0
     await reloaded.save(makeSaveData([item]))
-    t.assert.strictEqual(unlinkCalls, 0)
-})
-
-test('POFile does not touch url catalogs when url handling is disabled', async (t: TestContext) => {
-    let unlinkCalls = 0
-    const fs = {
-        ...inMemFS,
-        unlink(file: string) {
-            unlinkCalls++
-            return inMemFS.unlink(file)
-        },
-    }
-    const po = new POFile({
-        dir: 'src/locales',
-        separateUrls: true,
-        locales: ['en', 'es'],
-        root: '/projects-no-url-support',
-        haveUrl: false,
-        localesDir: 'src/locales',
-        sourceLocale: 'en',
-        fs,
-    })
-    await po.save(makeSaveData([item]))
     t.assert.strictEqual(unlinkCalls, 0)
 })
 

--- a/packages/wuchale/src/pofile.ts
+++ b/packages/wuchale/src/pofile.ts
@@ -166,7 +166,7 @@ export class POFile {
     opts: StorageFactoryOpts & POFileOptions
     filesByLoc: Map<string, [string, string]> = new Map() // main and url
     files: string[] = []
-    knownFiles: Map<string, boolean> = new Map()
+    fileExistsCache: Map<string, boolean> = new Map()
 
     constructor(opts: StorageFactoryOpts & POFileOptions) {
         this.opts = opts
@@ -185,7 +185,7 @@ export class POFile {
     async loadRaw(locale: string, url: boolean): Promise<PO | null> {
         const filename = this.filesByLoc.get(locale)![Number(url)]!
         const content = await this.opts.fs.read(filename)
-        this.knownFiles.set(filename, content != null)
+        this.fileExistsCache.set(filename, content != null)
         return content == null ? null : PO.parse(content)
     }
 
@@ -226,32 +226,26 @@ export class POFile {
     async saveRaw(items: POItem[], headers: POHeaders, locale: string, url: boolean) {
         const filename = this.filesByLoc.get(locale)![Number(url)]!
         if (items.length === 0) {
-            if (this.knownFiles.get(filename) === false) {
+            if (this.fileExistsCache.get(filename) === false) {
                 return
             }
-            try {
+            if (this.opts.fs.exists(filename)) {
                 await this.opts.fs.unlink(filename)
-                this.knownFiles.set(filename, false)
-            } catch (err: any) {
-                if (err.code !== 'ENOENT') {
-                    throw err
-                }
-                this.knownFiles.set(filename, false)
             }
+            this.fileExistsCache.set(filename, false)
             return
         }
         const po = new PO()
         po.headers = headers
         po.items = items
         await this.opts.fs.write(filename, po.toString())
-        this.knownFiles.set(filename, true)
+        this.fileExistsCache.set(filename, true)
     }
 
     async save(data: SaveData) {
-        await this.opts.fs.mkdir(this.opts.dir)
         const useSeparateUrls = this.opts.separateUrls && this.opts.haveUrl
         await Promise.all(
-            this.opts.locales.map(async locale => {
+            this.opts.locales.flatMap(locale => {
                 const poItems: POItem[] = []
                 const poItemsUrl: POItem[] = []
                 for (const item of data.items) {
@@ -263,10 +257,11 @@ export class POFile {
                     }
                 }
                 const headers = this.getHeaders(locale, data.pluralRules.get(locale)!)
-                await this.saveRaw(poItems, headers, locale, false)
+                const saveJobs = [this.saveRaw(poItems, headers, locale, false)]
                 if (useSeparateUrls) {
-                    await this.saveRaw(poItemsUrl, headers, locale, true)
+                    saveJobs.push(this.saveRaw(poItemsUrl, headers, locale, true))
                 }
+                return saveJobs
             }),
         )
     }
@@ -289,9 +284,9 @@ export class POFile {
 }
 
 export function pofile(pofOpts: Partial<POFileOptions> = {}): StorageFactory {
-    return opts =>
-        new POFile({
-            ...opts,
-            ...fillDefaults(pofOpts, { ...defaultOpts, dir: opts.localesDir }),
-        })
+    return async opts => {
+        const fullOpts = fillDefaults(pofOpts, { ...defaultOpts, dir: opts.localesDir })
+        await opts.fs.mkdir(fullOpts.dir) // create once
+        return new POFile({ ...opts, ...fullOpts })
+    }
 }

--- a/packages/wuchale/src/pofile.ts
+++ b/packages/wuchale/src/pofile.ts
@@ -166,6 +166,7 @@ export class POFile {
     opts: StorageFactoryOpts & POFileOptions
     filesByLoc: Map<string, [string, string]> = new Map() // main and url
     files: string[] = []
+    knownFiles: Map<string, boolean> = new Map()
 
     constructor(opts: StorageFactoryOpts & POFileOptions) {
         this.opts = opts
@@ -184,6 +185,7 @@ export class POFile {
     async loadRaw(locale: string, url: boolean): Promise<PO | null> {
         const filename = this.filesByLoc.get(locale)![Number(url)]!
         const content = await this.opts.fs.read(filename)
+        this.knownFiles.set(filename, content != null)
         return content == null ? null : PO.parse(content)
     }
 
@@ -224,34 +226,49 @@ export class POFile {
     async saveRaw(items: POItem[], headers: POHeaders, locale: string, url: boolean) {
         const filename = this.filesByLoc.get(locale)![Number(url)]!
         if (items.length === 0) {
-            if (await this.opts.fs.exists(filename)) {
+            if (this.knownFiles.get(filename) === false) {
+                return
+            }
+            try {
                 await this.opts.fs.unlink(filename)
+                this.knownFiles.set(filename, false)
+            } catch (err: any) {
+                if (err.code !== 'ENOENT') {
+                    throw err
+                }
+                this.knownFiles.set(filename, false)
             }
             return
         }
         const po = new PO()
         po.headers = headers
         po.items = items
-        await this.opts.fs.mkdir(this.opts.dir)
         await this.opts.fs.write(filename, po.toString())
+        this.knownFiles.set(filename, true)
     }
 
     async save(data: SaveData) {
-        for (const locale of this.opts.locales) {
-            const poItems: POItem[] = []
-            const poItemsUrl: POItem[] = []
-            for (const item of data.items) {
-                const poItem = itemToPOItem(item, locale, this.opts.sourceLocale)
-                if (itemIsUrl(item) && this.opts.separateUrls && this.opts.haveUrl) {
-                    poItemsUrl.push(poItem)
-                } else {
-                    poItems.push(poItem)
+        await this.opts.fs.mkdir(this.opts.dir)
+        const useSeparateUrls = this.opts.separateUrls && this.opts.haveUrl
+        await Promise.all(
+            this.opts.locales.map(async locale => {
+                const poItems: POItem[] = []
+                const poItemsUrl: POItem[] = []
+                for (const item of data.items) {
+                    const poItem = itemToPOItem(item, locale, this.opts.sourceLocale)
+                    if (itemIsUrl(item) && useSeparateUrls) {
+                        poItemsUrl.push(poItem)
+                    } else {
+                        poItems.push(poItem)
+                    }
                 }
-            }
-            const headers = this.getHeaders(locale, data.pluralRules.get(locale)!)
-            await this.saveRaw(poItems, headers, locale, false)
-            await this.saveRaw(poItemsUrl, headers, locale, true)
-        }
+                const headers = this.getHeaders(locale, data.pluralRules.get(locale)!)
+                await this.saveRaw(poItems, headers, locale, false)
+                if (useSeparateUrls) {
+                    await this.saveRaw(poItemsUrl, headers, locale, true)
+                }
+            }),
+        )
     }
 
     getHeaders(locale: string, pluralRule: PluralRule) {


### PR DESCRIPTION
## Summary

This PR reduces unnecessary work in `pofile` saves by tightening three behaviors in the storage layer:

- create the locales directory once per save instead of once per written file
- stop repeatedly trying to delete URL sidecar files once their absence is already known
- stop touching URL sidecar files at all when URL handling is disabled for the adapter

The goal is simple: if `wuchale` already knows a file state and that state does not need changing, it should not keep paying IO and watcher costs for it.

In a linked consumer debugging session, these save-path changes were a meaningful part of reducing startup cost and catalog-change churn. This PR isolates just the storage-side improvements so they can be reviewed independently from other fixes.

## Simplified Explanation

Before this PR, `pofile` did more work than necessary while saving catalogs:

- it could call `mkdir()` over and over for the same save operation
- it could keep trying to delete the same missing `*.url.po` files again and again
- it could still walk the URL-sidecar save path even when the adapter was not using URL catalogs at all

That behavior is correct in the sense that it eventually lands in the right filesystem state, but it is wasteful.

This PR teaches `pofile` three simple rules:

- make the directory once
- remember when a sidecar file is already known missing
- do not manage URL sidecars when URL handling is off

That preserves behavior while removing repeated no-op filesystem work.

## Problem

`POFile.save()` previously had a few avoidable costs:

### 1. Repeated directory creation inside `saveRaw()`

Every non-empty file write called `mkdir(this.opts.dir)` from inside `saveRaw()`.

That means one logical save operation could repeat the same directory creation check for every locale and every sidecar file.

### 2. Repeated `exists()` / `unlink()` work for missing URL sidecars

When saving an empty URL sidecar, `saveRaw()` checked:

- does the file exist?
- if yes, unlink it

If the file was already missing, later saves would still repeat that same existence check.

In practice, this can happen a lot when:

- `separateUrls` is enabled
- the storage knows about sidecar paths
- but there are no URL items to write

### 3. URL-sidecar save logic still ran even when URL handling was disabled

`POFile.load()` already gated URL sidecar loading behind:

- `separateUrls && haveUrl`

But `POFile.save()` still evaluated the URL-sidecar save path unconditionally and only decided per-item whether a message should go into the sidecar.

That meant it could still attempt sidecar cleanup work even when `haveUrl === false`, which is unnecessary in adapters that are not using URL storage at all.

## What Changed

### `mkdir()` now happens once per save

`POFile.save()` now calls:

```ts
await this.opts.fs.mkdir(this.opts.dir)
```

once before processing locales.

`saveRaw()` no longer repeats that work for each file.

### Missing sidecar state is cached

`POFile` now tracks a small `knownFiles` map.

- `loadRaw()` records whether a file was present
- successful writes mark a file as known present
- successful or `ENOENT` unlinks mark a file as known absent

When `saveRaw()` is asked to save an empty file and the file is already known absent, it returns immediately without another filesystem call.

### URL-sidecar work is skipped entirely when URL handling is off

`save()` now computes:

```ts
const useSeparateUrls = this.opts.separateUrls && this.opts.haveUrl
```

and only:

- classifies URL items into the sidecar bucket when that is true
- calls `saveRaw(..., url = true)` when that is true

This makes save behavior consistent with the existing load behavior.

## Why This Is Safe

These changes do not alter catalog contents or translation semantics.

They only reduce redundant filesystem work.

### Directory creation

Moving `mkdir()` outward is safe because all file writes in that save still target the same directory.

### Known-missing sidecars

Caching the known absence of a sidecar is safe because the cache is refreshed by normal storage loads:

- if the file exists on disk later, `loadRaw()` will observe that and mark it known present
- if it remains missing, skipping repeated unlink attempts is a no-op optimization

### `haveUrl === false`

When URL handling is disabled, there is no valid reason for `POFile.save()` to manage URL sidecars. Skipping that path is therefore behavior-preserving and more precise.

## Regression Coverage

This PR adds two focused regression tests in `packages/wuchale/src/pofile.test.ts`.

### `POFile skips unlinking missing url catalogs once their absence is known`

The test:

- creates a `POFile`
- saves once so the initial state is known
- reloads into a fresh `POFile` instance
- spies on `unlink()`
- saves again with no URL sidecars needed
- asserts that `unlink()` is not called again for already-known-missing sidecars

Without this change, the storage keeps doing redundant sidecar cleanup work.

### `POFile does not touch url catalogs when url handling is disabled`

The test:

- creates a `POFile` with `haveUrl: false`
- spies on `unlink()`
- saves normal message data
- asserts that the URL-sidecar path is never touched

Without this fix, `save()` can still perform sidecar cleanup attempts even though URL handling is disabled.

## Validation

Targeted validation was run in the linked debugging checkout where the same source changes were active:

```bash
cd packages/wuchale/src
node --import ../testing/resolve.ts pofile.test.ts
```

Result:

- all `pofile.test.ts` tests passed
- both new save-path regressions passed

These changes were also measured in the linked consumer app during the debugging session that motivated them:

- save-path work dropped materially after hoisting `mkdir()` and removing repeated sidecar cleanup
- startup churn from unnecessary filesystem work was reduced accordingly

## Technical Notes

This PR deliberately keeps the implementation small and local to `POFile`.

It does not introduce a broader cache layer or any global invalidation mechanism.

The `knownFiles` map is only used to avoid repeating file operations that `POFile` itself already learned the result of during its normal load/save lifecycle.

That keeps the optimization understandable and low-risk.

## Scope

This PR intentionally does not include:

- the extracted-comment alignment fix from the separate `pofile` correctness PR
- profiling instrumentation used during local debugging
- `dist/` edits from the linked local consumer setup
- unrelated startup or HMR changes elsewhere in `wuchale`

This PR is only about one class of improvements:

reducing redundant filesystem work in `pofile` save operations.
