### PR TITLE
[codex] fix useReactive fallback

### DIFF
--- a/packages/wuchale/src/adapter-vanilla/transformer.test.ts
+++ b/packages/wuchale/src/adapter-vanilla/transformer.test.ts
@@ -175,6 +175,46 @@ test('Runtime init place', t => {
     )
 })
 
+test('useReactive nullish fallback stays boolean', t => {
+    transformTest(
+        t,
+        new Transformer(
+            ts`
+            function foo() {
+                return 'Hello'
+            }
+        `,
+            filename,
+            new IndexTracker(),
+            defaultArgs.heuristic,
+            defaultArgs.patterns,
+            catalogExpr,
+            {
+                initReactive: () => false,
+                useReactive: ({ funcName }) => (funcName == null ? false : undefined),
+                plain: {
+                    wrapInit: expr => expr,
+                    wrapUse: expr => `plainUse(${expr})`,
+                },
+                reactive: {
+                    wrapInit: expr => expr,
+                    wrapUse: expr => `reactiveUse(${expr})`,
+                },
+            } as RuntimeConf,
+            urlHandler.match,
+        ).transform(),
+        ts`
+        import { _w_load_, _w_load_rx_ } from "./loader.js"
+
+        function foo() {
+            const _w_runtime_ = _w_load_();
+            return plainUse(_w_runtime_)(0)
+        }
+    `,
+        ['Hello'],
+    )
+})
+
 test('Plural and patterns', t => {
     transformTest(
         t,

--- a/packages/wuchale/src/adapter-vanilla/transformer.ts
+++ b/packages/wuchale/src/adapter-vanilla/transformer.ts
@@ -114,12 +114,13 @@ export class Transformer {
         this.matchUrl = matchUrl
         const topLevelUseReactive =
             typeof rtConf.useReactive === 'boolean'
-                ? () => rtConf.useReactive
-                : {
+                ? rtConf.useReactive
+                : (rtConf.useReactive({
+                      funcName: undefined,
                       nested: false,
                       file: filename,
                       ctx: this.runtimeCtx,
-                  }
+                  }) ?? false)
 
         const vars: Record<string, { [key in 'plain' | 'reactive']: RuntimeVars }> = {}
         // to enable the use of different runtime vars for different places, right now for svelte <script module>s


### PR DESCRIPTION
## Summary
- fix the vanilla transformer fallback so `useReactive` falls back to a real boolean instead of a truthy object
- add a regression test covering a nested scope where `useReactive()` returns `undefined`

## Root cause
`packages/wuchale/src/adapter-vanilla/transformer.ts` stored an object in `topLevelUseReactive` when `runtime.useReactive` was a function. When a later `useReactive(...)` call returned `undefined`, the nullish fallback picked that object, which is truthy, and incorrectly selected the reactive runtime vars.

## Validation
- Added the regression test first and confirmed it failed before the fix:
  - `node --import ./testing/resolve.ts --test src/adapter-vanilla/transformer.test.ts`
- Re-ran after the fix:
  - `node --import ./testing/resolve.ts --test src/adapter-vanilla/index.test.ts src/adapter-vanilla/transformer.test.ts`
