### PR TITLE
[codex] guard svelte derived wrapping

### DIFF
--- a/packages/svelte/src/transformer.test.ts
+++ b/packages/svelte/src/transformer.test.ts
@@ -14,7 +14,7 @@ const urlHandler = new URLHandler(['en'], 'en', {
 
 const catalogExpr = { plain: '_w_load_()', reactive: '_w_load_rx_()' }
 
-const getOutput = (content: string, filename = 'test.svelte') =>
+const getOutput = (content: string, filename = 'test.svelte', runtime = defaultArgs.runtime as RuntimeConf) =>
     new SvelteTransformer(
         content,
         filename,
@@ -22,7 +22,7 @@ const getOutput = (content: string, filename = 'test.svelte') =>
         defaultArgs.heuristic,
         defaultArgs.patterns,
         catalogExpr,
-        defaultArgs.runtime as RuntimeConf,
+        runtime,
         urlHandler.match,
     ).transformSv()
 
@@ -81,6 +81,34 @@ test('JS module files', async t => {
         }
     `,
         ['Simple bare assign', 'Foo', 'Hello', 'Should extract'],
+    )
+})
+
+test('Plain JS files respect runtime reactive overrides', async t => {
+    transformTest(
+        t,
+        await getOutput(
+            ts`
+            const LINK_TYPES = {
+                docs: 'Docs'
+            }
+        `,
+            'developer-links.js',
+            {
+                ...defaultArgs.runtime,
+                initReactive: () => false,
+                useReactive: () => false,
+            } as RuntimeConf,
+        ),
+        ts`
+        import { _w_load_, _w_load_rx_ } from "./loader.js"
+
+        const _w_runtime_ = _w_load_();
+        const LINK_TYPES = {
+            docs: _w_runtime_(0)
+        }
+    `,
+        ['Docs'],
     )
 })
 

--- a/packages/svelte/src/transformer.ts
+++ b/packages/svelte/src/transformer.ts
@@ -76,11 +76,13 @@ export class SvelteTransformer extends Transformer {
     override visitVariableDeclarator = (node: VariableDeclarator): Message[] => {
         const msgs = this.defaultVisitVariableDeclarator(node)
         const init = node.init
+        const filename = this.heuristciDetails.file
         if (
             !msgs.length ||
             this.heuristciDetails.declaring != null ||
             init == null ||
-            ['ArrowFunctionExpression', 'FunctionExpression'].includes(init.type)
+            ['ArrowFunctionExpression', 'FunctionExpression'].includes(init.type) ||
+            !['.svelte', '.svelte.js', '.svelte.ts'].some(ext => filename.endsWith(ext))
         ) {
             return msgs
         }


### PR DESCRIPTION
## Summary
- stop the Svelte transformer from auto-wrapping translated variable initializers in `$derived(...)` for non-Svelte files
- add a regression test covering a plain `developer-links.js` input with `initReactive/useReactive` forced off

## Root cause
`packages/svelte/src/transformer.ts` injected `$derived(...)` in `visitVariableDeclarator` based only on extracted messages. It did not guard against plain `.js/.ts` files, so a non-Svelte file processed through the Svelte adapter could still emit invalid rune syntax.

## Validation
- Added the regression test first and confirmed it failed before the fix:
  - `node --import ../wuchale/testing/resolve.ts --test src/transformer.test.ts`
- Re-ran after the fix:
  - `node --import ../wuchale/testing/resolve.ts --test src/index.test.ts src/transformer.test.ts`
