### PR TITLE
Number load IDs, granular loading grouped with glob patterns

### DIFF
--- a/.changeset/yummy-plums-reply.md
+++ b/.changeset/yummy-plums-reply.md
@@ -1,0 +1,44 @@
+---
+"wuchale": minor
+"@wuchale/svelte": minor
+"@wuchale/astro": minor
+"@wuchale/jsx": minor
+---
+
+⚠️ BREAKING: reorganize loading config, use glob patterns and number load IDs
+
+- `granularLoad` is now `loading.granular`
+- `bundleLoad` is now `loading.direct`
+- `generateLoadID` is replaced by a glob config at `loading.group`
+
+Therefore if you use any of these, update your config like this:
+
+```diff
+-import { defineConfig, defaultGenerateLoadID, pofile } from "wuchale"
++import { defineConfig, pofile } from "wuchale"
+import { adapter as svelte } from '@wuchale/svelte'
+ 
+export default defineConfig({
+    // ...
+    adapters: {
+        main: svelte({
+            // ...
+           bundleLoad: true,
+-          granularLoad: true,
+-          generateLoadID: filename => {
+-              if (filename.includes('grouped')) {
+-                  return 'grouped'
+-              }
+-              return defaultGenerateLoadID(filename)
+-          },
++          loading: {
++              granular: true,
++              direct: true,
++              group: [
++                  '**/*grouped*',
++              ]
++          }
+       }),
+    }
+})
+```

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -7,7 +7,7 @@ import type {
     LoaderChoice,
     RuntimeConf,
 } from 'wuchale'
-import { createHeuristic, defaultGenerateLoadID, defaultHeuristicOpts, fillDefaults, pofile } from 'wuchale'
+import { createHeuristic, defaultHeuristicOpts, fillDefaults, pofile } from 'wuchale'
 import { loaderPathResolver } from 'wuchale/adapter-utils'
 import { pluralPattern } from 'wuchale/adapter-vanilla'
 import { AstroTransformer } from './transformer.js'
@@ -34,10 +34,7 @@ export const astroDefaultHeuristic = createAstroHeuristic(defaultHeuristicOpts)
 type LoadersAvailable = 'default'
 
 // astro is an SSR framework, omit irrelevant
-export type AstroArgs = Omit<
-    AdapterArgs<LoadersAvailable>,
-    'bundleLoad' | 'granularLoad' | 'generateLoadID' | 'runtime'
->
+export type AstroArgs = Omit<AdapterArgs<LoadersAvailable>, 'loading' | 'runtime'>
 
 export const defaultRuntime: RuntimeConf = {
     // Astro is SSR-only, so we use non-reactive runtime by default
@@ -89,9 +86,11 @@ export const adapter = (args: DeepPartial<AstroArgs> = defaultArgs): Adapter => 
         },
         loaderExts: ['.js', '.ts'],
         defaultLoaderPath: getDefaultLoaderPath(loader),
-        granularLoad: false,
-        bundleLoad: false,
-        generateLoadID: defaultGenerateLoadID,
+        loading: {
+            direct: false,
+            granular: false,
+            group: [],
+        },
         runtime: defaultRuntime,
         ...rest,
     }

--- a/packages/astro/src/loaders/astro.js
+++ b/packages/astro/src/loaders/astro.js
@@ -2,14 +2,14 @@
 // This is a template file that wuchale will use to generate the actual loader
 
 import { currentRuntime } from 'wuchale/load-utils/server'
-import { loadCatalog, loadIDs } from '${PROXY_SYNC}'
+import { loadCatalog, patterns } from '${PROXY_SYNC}'
 
 const key = '${KEY}'
 
-export { key, loadCatalog, loadIDs }
+export { key, loadCatalog, patterns }
 
 // For non-reactive server-side rendering
-export const getRuntime = (/** @type {string} */ loadID) => currentRuntime(key, loadID)
+export const getRuntime = (loadID = 0) => currentRuntime(key, loadID)
 
 // Same function for compatibility
 export const getRuntimeRx = getRuntime

--- a/packages/astro/src/loaders/astro.js
+++ b/packages/astro/src/loaders/astro.js
@@ -2,11 +2,11 @@
 // This is a template file that wuchale will use to generate the actual loader
 
 import { currentRuntime } from 'wuchale/load-utils/server'
-import { loadCatalog, patterns } from '${PROXY_SYNC}'
+import { loadCatalog, loadCount } from '${PROXY_SYNC}'
 
 const key = '${KEY}'
 
-export { key, loadCatalog, patterns }
+export { key, loadCatalog, loadCount }
 
 // For non-reactive server-side rendering
 export const getRuntime = (loadID = 0) => currentRuntime(key, loadID)

--- a/packages/jsx/src/declare.d.ts
+++ b/packages/jsx/src/declare.d.ts
@@ -1,6 +1,6 @@
 declare module 'solid-js' {
     export function For(props: any): any
-    export function createSignal(init: any): [Function, Function]
+    export function createSignal<T>(init: T): [() => T, ((a: T | (() => T)) => void)]
 }
 
 declare module 'solid-js/store' {
@@ -8,7 +8,7 @@ declare module 'solid-js/store' {
 }
 
 declare module 'react' {
-    export function useState(init: any): [any, Function]
+    export function useState<T>(init: T | (() => T)): [T, ((a: T | (() => T)) => void)]
     export function useEffect(cb: Function, deps: Array): any
     export function useMemo(cb: Function, deps: Array): any
 }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -7,7 +7,7 @@ import type {
     LoaderChoice,
     RuntimeConf,
 } from 'wuchale'
-import { createHeuristic, defaultGenerateLoadID, defaultHeuristicOpts, fillDefaults, pofile } from 'wuchale'
+import { createHeuristic, defaultHeuristicOpts, fillDefaults, pofile } from 'wuchale'
 import { loaderPathResolver } from 'wuchale/adapter-utils'
 import { getDefaultLoaderPath as getDefaultLoaderPathVanilla, pluralPattern } from 'wuchale/adapter-vanilla'
 import { type JSXLib, JSXTransformer } from './transformer.js'
@@ -75,10 +75,12 @@ export const defaultArgs: JSXArgs = {
     storage: pofile(),
     patterns: [pluralPattern],
     heuristic: jsxDefaultHeuristic,
-    granularLoad: false,
-    bundleLoad: false,
+    loading: {
+        direct: false,
+        granular: false,
+        group: [],
+    },
     loader: 'default',
-    generateLoadID: defaultGenerateLoadID,
     runtime: defaultRuntime,
     variant: 'default',
 }
@@ -117,7 +119,7 @@ export const adapter = (args: DeepPartial<JSXArgs> = defaultArgs): Adapter => {
             ).transformJx(variant)
         },
         loaderExts: ['.js', '.ts'],
-        defaultLoaderPath: getDefaultLoaderPath(loader, rest.bundleLoad),
+        defaultLoaderPath: getDefaultLoaderPath(loader, rest.loading.direct),
         runtime,
         getRuntimeVars: {
             reactive: 'useW_load_rx_',

--- a/packages/jsx/src/loaders/react.bundle.js
+++ b/packages/jsx/src/loaders/react.bundle.js
@@ -19,16 +19,21 @@ export function setLocale(locale) {
     }
 }
 
-export const getRuntimeRx = (/** @type {{[locale: string]: import('wuchale/runtime').CatalogModule }} */ catalogs) => {
+/**
+ * @param {{[locale in import('${DATA}').Locale]: import('wuchale/runtime').CatalogModule }} catalogs
+ */
+export const getRuntimeRx = catalogs => {
     const [locale, setLocale] = useState(locales[0])
     useEffect(() => {
-        const cb = (/** @type {string} */ locale) => setLocale(locale)
+        const cb = (/** @type {import('${DATA}').Locale} */ locale) => setLocale(locale)
         callbacks.add(cb)
         return () => callbacks.delete(cb)
     }, [catalogs])
     return useMemo(() => toRuntime(catalogs[locale], locale), [locale, catalogs])
 }
 
-// non-reactive
-export const getRuntime = (/** @type {{[locale: string]: import('wuchale/runtime').CatalogModule }} */ catalogs) =>
-    toRuntime(catalogs[locale], locale)
+/**
+ * non-reactive
+ * @param {{[locale in import('${DATA}').Locale]: import('wuchale/runtime').CatalogModule }} catalogs
+ */
+export const getRuntime = catalogs => toRuntime(catalogs[locale], locale)

--- a/packages/jsx/src/loaders/react.js
+++ b/packages/jsx/src/loaders/react.js
@@ -1,20 +1,19 @@
 import { useEffect, useState } from 'react'
 import { registerLoaders } from 'wuchale/load-utils'
-import { loadCatalog, loadIDs } from '${PROXY}'
+import { loadCatalog, nLoadIDs } from '${PROXY}'
 
 export const key = '${KEY}'
-/** @type {{[loadID: string]: Set<Function>}} */
-const callbacks = {}
-/** @type {{[loadID: string]: import('wuchale/runtime').Runtime}} */
-const store = {}
+/** @type {Set<Function>[]} */
+const callbacks = []
+/** @type {import('wuchale/runtime').Runtime[]} */
+const store = []
 
 // non-reactive
-export const getRuntime = (/** @type {string} */ loadID) =>
-    /** @type {import('wuchale/runtime').Runtime} */ (store[loadID])
+export const getRuntime = (loadID = 0) => /** @type {import('wuchale/runtime').Runtime} */ (store[loadID])
 
 const collection = {
     get: getRuntime,
-    set: (/** @type {string} */ loadID, /** @type {import('wuchale/runtime').Runtime} */ runtime) => {
+    set: (/** @type {number} */ loadID, /** @type {import('wuchale/runtime').Runtime} */ runtime) => {
         store[loadID] = runtime // for when useEffect hasn't run yet
         callbacks[loadID]?.forEach(cb => {
             cb(runtime)
@@ -22,9 +21,9 @@ const collection = {
     },
 }
 
-registerLoaders(key, loadCatalog, loadIDs, collection)
+registerLoaders(key, loadCatalog, nLoadIDs, collection)
 
-export const getRuntimeRx = (/** @type {string} */ loadID) => {
+export const getRuntimeRx = (loadID = 0) => {
     // function to useState because runtime is a function too
     const [runtime, setRuntime] = useState(() => getRuntime(loadID))
     useEffect(() => {

--- a/packages/jsx/src/loaders/react.js
+++ b/packages/jsx/src/loaders/react.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { registerLoaders } from 'wuchale/load-utils'
-import { loadCatalog, nLoadIDs } from '${PROXY}'
+import { loadCatalog, loadCount } from '${PROXY}'
 
 export const key = '${KEY}'
 /** @type {Set<Function>[]} */
@@ -21,7 +21,7 @@ const collection = {
     },
 }
 
-registerLoaders(key, loadCatalog, nLoadIDs, collection)
+registerLoaders(key, loadCatalog, loadCount, collection)
 
 export const getRuntimeRx = (loadID = 0) => {
     // function to useState because runtime is a function too

--- a/packages/jsx/src/loaders/solidjs.bundle.js
+++ b/packages/jsx/src/loaders/solidjs.bundle.js
@@ -7,7 +7,7 @@ const [locale, setLocale] = createSignal(locales[0])
 export { setLocale }
 
 /**
- * @param {{ [locale: string]: import('wuchale/runtime').CatalogModule }} catalogs
+ * @param {{ [locale in import('${DATA}').Locale]: import('wuchale/runtime').CatalogModule }} catalogs
  */
 export const getRuntimeRx = catalogs => toRuntime(catalogs[locale()], locale())
 // same function, because solid-js can use them anywhere

--- a/packages/jsx/src/loaders/solidjs.js
+++ b/packages/jsx/src/loaders/solidjs.js
@@ -1,13 +1,13 @@
 import { createStore } from 'solid-js/store'
 import { registerLoaders } from 'wuchale/load-utils'
-import { loadCatalog, nLoadIDs } from '${PROXY}'
+import { loadCatalog, loadCount } from '${PROXY}'
 
 const key = '${KEY}'
 
 const [store, setStore] = createStore([])
 
 // two exports. can be the same because solid-js can use them anywhere unlike react
-export const getRuntimeRx = registerLoaders(key, loadCatalog, nLoadIDs, {
+export const getRuntimeRx = registerLoaders(key, loadCatalog, loadCount, {
     get: loadID => store[loadID],
     set: (loadID, runtime) => setStore(loadID, () => runtime),
 })

--- a/packages/jsx/src/loaders/solidjs.js
+++ b/packages/jsx/src/loaders/solidjs.js
@@ -1,13 +1,13 @@
 import { createStore } from 'solid-js/store'
 import { registerLoaders } from 'wuchale/load-utils'
-import { loadCatalog, loadIDs } from '${PROXY}'
+import { loadCatalog, nLoadIDs } from '${PROXY}'
 
 const key = '${KEY}'
 
-const [store, setStore] = createStore({})
+const [store, setStore] = createStore([])
 
 // two exports. can be the same because solid-js can use them anywhere unlike react
-export const getRuntimeRx = registerLoaders(key, loadCatalog, loadIDs, {
+export const getRuntimeRx = registerLoaders(key, loadCatalog, nLoadIDs, {
     get: loadID => store[loadID],
     set: (loadID, runtime) => setStore(loadID, () => runtime),
 })

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -8,7 +8,7 @@ import type {
     LoaderChoice,
     RuntimeConf,
 } from 'wuchale'
-import { createHeuristic, defaultGenerateLoadID, defaultHeuristicOpts, fillDefaults, pofile } from 'wuchale'
+import { createHeuristic, defaultHeuristicOpts, fillDefaults, pofile } from 'wuchale'
 import { loaderPathResolver } from 'wuchale/adapter-utils'
 import { pluralPattern } from 'wuchale/adapter-vanilla'
 import { type RuntimeCtxSv, SvelteTransformer } from './transformer.js'
@@ -68,9 +68,11 @@ export const defaultArgs: SvelteArgs = {
     storage: pofile(),
     patterns: [pluralPattern],
     heuristic: svelteDefaultHeuristic,
-    granularLoad: false,
-    bundleLoad: false,
-    generateLoadID: defaultGenerateLoadID,
+    loading: {
+        direct: false,
+        granular: false,
+        group: [],
+    },
     loader: 'svelte',
     runtime: {
         initReactive: ({ file, funcName, ctx: { module } }: DecideRxDetails) => {
@@ -129,7 +131,7 @@ export const adapter = (args: DeepPartial<SvelteArgs> = defaultArgs): Adapter =>
             ).transformSv()
         },
         loaderExts: ['.svelte.js', '.svelte.ts', '.js', '.ts'],
-        defaultLoaderPath: getDefaultLoaderPath(loader, rest.bundleLoad),
+        defaultLoaderPath: getDefaultLoaderPath(loader, rest.loading.direct),
         runtime,
         ...rest,
     }

--- a/packages/svelte/src/loaders/bundle.svelte.js
+++ b/packages/svelte/src/loaders/bundle.svelte.js
@@ -12,7 +12,7 @@ export function setLocale(newLocale) {
 
 // for non-reactive
 /**
- * @param {{ [locale: string]: import("wuchale/runtime").CatalogModule }} catalogs
+ * @param {{ [locale in import('${DATA}').Locale]: import("wuchale/runtime").CatalogModule }} catalogs
  */
 export const getRuntime = catalogs => toRuntime(catalogs[locale], locale)
 

--- a/packages/svelte/src/loaders/svelte.svelte.js
+++ b/packages/svelte/src/loaders/svelte.svelte.js
@@ -1,5 +1,5 @@
 import { defaultCollection, registerLoaders } from 'wuchale/load-utils'
-import { loadCatalog, nLoadIDs } from '${PROXY}'
+import { loadCatalog, loadCount } from '${PROXY}'
 
 const key = '${KEY}'
 
@@ -7,7 +7,7 @@ const key = '${KEY}'
 const runtimes = $state([])
 
 // for non-reactive
-export const getRuntime = registerLoaders(key, loadCatalog, nLoadIDs, defaultCollection(runtimes))
+export const getRuntime = registerLoaders(key, loadCatalog, loadCount, defaultCollection(runtimes))
 
 // same function, only will be inside $derived when used
 export const getRuntimeRx = getRuntime

--- a/packages/svelte/src/loaders/svelte.svelte.js
+++ b/packages/svelte/src/loaders/svelte.svelte.js
@@ -1,12 +1,13 @@
 import { defaultCollection, registerLoaders } from 'wuchale/load-utils'
-import { loadCatalog, loadIDs } from '${PROXY}'
+import { loadCatalog, nLoadIDs } from '${PROXY}'
 
 const key = '${KEY}'
 
-const runtimes = $state({})
+/** @type import('wuchale/runtime').Runtime[] */
+const runtimes = $state([])
 
 // for non-reactive
-export const getRuntime = registerLoaders(key, loadCatalog, loadIDs, defaultCollection(runtimes))
+export const getRuntime = registerLoaders(key, loadCatalog, nLoadIDs, defaultCollection(runtimes))
 
 // same function, only will be inside $derived when used
 export const getRuntimeRx = getRuntime

--- a/packages/svelte/src/loaders/sveltekit.ssr.svelte.js
+++ b/packages/svelte/src/loaders/sveltekit.ssr.svelte.js
@@ -1,9 +1,9 @@
 import { currentRuntime } from 'wuchale/load-utils/server'
-import { loadCatalog, nLoadIDs } from '${PROXY_SYNC}'
+import { loadCatalog, loadCount } from '${PROXY_SYNC}'
 
 const key = '${KEY}'
 
-export { key, loadCatalog, nLoadIDs } // for hooks.server.{js,ts}
+export { key, loadCatalog, loadCount } // for hooks.server.{js,ts}
 
 // for non-reactive
 export const getRuntime = (loadID = 0) => currentRuntime(key, loadID)

--- a/packages/svelte/src/loaders/sveltekit.ssr.svelte.js
+++ b/packages/svelte/src/loaders/sveltekit.ssr.svelte.js
@@ -1,12 +1,12 @@
 import { currentRuntime } from 'wuchale/load-utils/server'
-import { loadCatalog, loadIDs } from '${PROXY_SYNC}'
+import { loadCatalog, nLoadIDs } from '${PROXY_SYNC}'
 
 const key = '${KEY}'
 
-export { key, loadCatalog, loadIDs } // for hooks.server.{js,ts}
+export { key, loadCatalog, nLoadIDs } // for hooks.server.{js,ts}
 
 // for non-reactive
-export const getRuntime = (/** @type {string} */ loadID) => currentRuntime(key, loadID)
+export const getRuntime = (loadID = 0) => currentRuntime(key, loadID)
 
 // same function, only will be inside $derived when used
 export const getRuntimeRx = getRuntime

--- a/packages/wuchale/ambient.d.ts
+++ b/packages/wuchale/ambient.d.ts
@@ -1,13 +1,16 @@
 // these are substituted for default loaders
+// this file exists to type check the loader templates
 
 declare module '${PROXY}' {
-    export function loadCatalog(loadID: string, locale: string): Promise<import('wuchale/runtime').CatalogModule>
-    export const loadIDs: string[]
+    export const nLoadIDs: number
+    export function loadCatalog(loadID: number, locale: string): Promise<import('wuchale/runtime').CatalogModule>
+    export const patterns: import('wuchale').LoadGroupPatt[]
 }
 
 declare module '${PROXY_SYNC}' {
-    export function loadCatalog(loadID: string, locale: string): import('wuchale/runtime').CatalogModule
-    export const loadIDs: string[]
+    export const nLoadIDs: number
+    export function loadCatalog(loadID: number, locale: string): import('wuchale/runtime').CatalogModule
+    export const patterns: import('wuchale').LoadGroupPatt[]
 }
 
 declare module '${DATA}' {

--- a/packages/wuchale/ambient.d.ts
+++ b/packages/wuchale/ambient.d.ts
@@ -2,13 +2,13 @@
 // this file exists to type check the loader templates
 
 declare module '${PROXY}' {
-    export const nLoadIDs: number
+    export const loadCount: number
     export function loadCatalog(loadID: number, locale: string): Promise<import('wuchale/runtime').CatalogModule>
     export const patterns: import('wuchale').LoadGroupPatt[]
 }
 
 declare module '${PROXY_SYNC}' {
-    export const nLoadIDs: number
+    export const loadCount: number
     export function loadCatalog(loadID: number, locale: string): import('wuchale/runtime').CatalogModule
     export const patterns: import('wuchale').LoadGroupPatt[]
 }

--- a/packages/wuchale/src/adapter-vanilla/index.ts
+++ b/packages/wuchale/src/adapter-vanilla/index.ts
@@ -2,7 +2,7 @@
 
 import { loaderPathResolver } from '../adapter-utils/index.js'
 import type { Adapter, AdapterArgs, CodePattern, LoaderChoice, RuntimeConf } from '../adapters.js'
-import { defaultGenerateLoadID, defaultHeuristicFuncOnly } from '../adapters.js'
+import { defaultHeuristicFuncOnly } from '../adapters.js'
 import { type DeepPartial, fillDefaults } from '../config.js'
 import { pofile } from '../pofile.js'
 import { Transformer } from './transformer.js'
@@ -24,9 +24,11 @@ export const defaultArgs: VanillaArgs = {
     storage: pofile(),
     patterns: [pluralPattern],
     heuristic: defaultHeuristicFuncOnly,
-    granularLoad: false,
-    bundleLoad: false,
-    generateLoadID: defaultGenerateLoadID,
+    loading: {
+        direct: false,
+        granular: false,
+        group: [],
+    },
     loader: 'vite',
     runtime: {
         initReactive: ({ nested }) => (nested ? null : false),
@@ -75,7 +77,7 @@ export const adapter = (args: DeepPartial<VanillaArgs> = defaultArgs): Adapter =
                 matchUrl,
             ).transform(),
         loaderExts: ['.js', '.ts'],
-        defaultLoaderPath: getDefaultLoaderPath(loader, rest.bundleLoad),
+        defaultLoaderPath: getDefaultLoaderPath(loader, rest.loading.direct),
         runtime,
         ...rest,
     }

--- a/packages/wuchale/src/adapter-vanilla/loaders/bundle.js
+++ b/packages/wuchale/src/adapter-vanilla/loaders/bundle.js
@@ -11,7 +11,7 @@ export function setLocale(newLocale) {
 }
 
 /**
- * @param {{ [locale: string]: import("wuchale/runtime").CatalogModule }} catalogs
+ * @param {{ [locale in import('${DATA}').Locale]: import("wuchale/runtime").CatalogModule }} catalogs
  */
 export const getRuntime = catalogs => toRuntime(catalogs[locale], locale)
 export const getRuntimeRx = getRuntime

--- a/packages/wuchale/src/adapter-vanilla/loaders/server.js
+++ b/packages/wuchale/src/adapter-vanilla/loaders/server.js
@@ -1,10 +1,10 @@
 import { loadLocales } from 'wuchale/load-utils/server'
 import { locales } from '${DATA}'
-import { loadCatalog, nLoadIDs } from '${PROXY_SYNC}'
+import { loadCatalog, loadCount } from '${PROXY_SYNC}'
 
-export { loadCatalog, nLoadIDs }
+export { loadCatalog, loadCount }
 export const key = '${KEY}'
 
 // two exports
-export const getRuntime = await loadLocales(key, nLoadIDs, loadCatalog, locales)
+export const getRuntime = await loadLocales(key, loadCount, loadCatalog, locales)
 export const getRuntimeRx = getRuntime

--- a/packages/wuchale/src/adapter-vanilla/loaders/server.js
+++ b/packages/wuchale/src/adapter-vanilla/loaders/server.js
@@ -1,10 +1,10 @@
 import { loadLocales } from 'wuchale/load-utils/server'
 import { locales } from '${DATA}'
-import { loadCatalog, loadIDs } from '${PROXY_SYNC}'
+import { loadCatalog, nLoadIDs } from '${PROXY_SYNC}'
 
-export { loadCatalog, loadIDs }
+export { loadCatalog, nLoadIDs }
 export const key = '${KEY}'
 
 // two exports
-export const getRuntime = await loadLocales(key, loadIDs, loadCatalog, locales)
+export const getRuntime = await loadLocales(key, nLoadIDs, loadCatalog, locales)
 export const getRuntimeRx = getRuntime

--- a/packages/wuchale/src/adapter-vanilla/loaders/vite.js
+++ b/packages/wuchale/src/adapter-vanilla/loaders/vite.js
@@ -1,8 +1,8 @@
 import { registerLoaders } from 'wuchale/load-utils'
-import { loadCatalog, nLoadIDs } from '${PROXY}'
+import { loadCatalog, loadCount } from '${PROXY}'
 
 const key = '${KEY}'
 
 // two exports. can be used anywhere
-export const getRuntime = registerLoaders(key, loadCatalog, nLoadIDs)
+export const getRuntime = registerLoaders(key, loadCatalog, loadCount)
 export const getRuntimeRx = getRuntime

--- a/packages/wuchale/src/adapter-vanilla/loaders/vite.js
+++ b/packages/wuchale/src/adapter-vanilla/loaders/vite.js
@@ -1,8 +1,8 @@
 import { registerLoaders } from 'wuchale/load-utils'
-import { loadCatalog, loadIDs } from '${PROXY}'
+import { loadCatalog, nLoadIDs } from '${PROXY}'
 
 const key = '${KEY}'
 
 // two exports. can be used anywhere
-export const getRuntime = registerLoaders(key, loadCatalog, loadIDs)
+export const getRuntime = registerLoaders(key, loadCatalog, nLoadIDs)
 export const getRuntimeRx = getRuntime

--- a/packages/wuchale/src/adapter-vanilla/loaders/vite.ssr.js
+++ b/packages/wuchale/src/adapter-vanilla/loaders/vite.ssr.js
@@ -1,8 +1,8 @@
 import { currentRuntime } from 'wuchale/load-utils/server'
-import { loadCatalog, nLoadIDs } from '${PROXY_SYNC}'
+import { loadCatalog, loadCount } from '${PROXY_SYNC}'
 
 export const key = '${KEY}'
-export { loadCatalog, nLoadIDs } // for loading before runWithLocale
+export { loadCatalog, loadCount } // for loading before runWithLocale
 
 // two exports, same function
 export const getRuntime = (loadID = 0) => currentRuntime(key, loadID)

--- a/packages/wuchale/src/adapter-vanilla/loaders/vite.ssr.js
+++ b/packages/wuchale/src/adapter-vanilla/loaders/vite.ssr.js
@@ -1,9 +1,9 @@
 import { currentRuntime } from 'wuchale/load-utils/server'
-import { loadCatalog, loadIDs } from '${PROXY_SYNC}'
+import { loadCatalog, nLoadIDs } from '${PROXY_SYNC}'
 
 export const key = '${KEY}'
-export { loadCatalog, loadIDs } // for loading before runWithLocale
+export { loadCatalog, nLoadIDs } // for loading before runWithLocale
 
 // two exports, same function
-export const getRuntime = (/** @type {string} */ loadID) => currentRuntime(key, loadID)
+export const getRuntime = (loadID = 0) => currentRuntime(key, loadID)
 export const getRuntimeRx = getRuntime

--- a/packages/wuchale/src/adapters.ts
+++ b/packages/wuchale/src/adapters.ts
@@ -146,8 +146,6 @@ export const defaultHeuristicFuncOnly: HeuristicFunc = msg => {
     return false
 }
 
-export const defaultGenerateLoadID = (filename: string) => filename.replace(/[^a-zA-Z0-9_]+/g, '_')
-
 export class IndexTracker {
     indices: Map<string, number> = new Map()
     nextIndex: number = 0
@@ -234,16 +232,20 @@ export type URLConf = {
     localize?: boolean | string
 }
 
+export type LoadGroupPatt = string | string[]
+
 export type AdapterPassThruOpts = {
     sourceLocale?: string
     files: GlobConf
     storage: StorageFactory
     /** if writing transformed code to a directory is desired, specify this */
     outDir?: string
-    granularLoad: boolean
-    bundleLoad: boolean
+    loading: {
+        direct: boolean
+        granular: boolean
+        group: LoadGroupPatt[]
+    }
     url?: URLConf
-    generateLoadID: (filename: string) => string
     runtime: RuntimeConf
 }
 

--- a/packages/wuchale/src/handler/files.ts
+++ b/packages/wuchale/src/handler/files.ts
@@ -1,12 +1,13 @@
 import { dirname, relative, resolve } from 'node:path'
 import { platform } from 'node:process'
-import type { Adapter, GlobConf, LoaderPath } from '../adapters.js'
+import type { Adapter, GlobConf, LoaderPath, LoadGroupPatt } from '../adapters.js'
 import type { CompiledElement } from '../compile.js'
 import type { FS } from '../fs.js'
 import type { URLManifest } from '../url.js'
 
 export const dataFileName = 'data.js'
 export const generatedDir = '.wuchale'
+export const defaultLoadID = 0
 
 export type ManifestEntryObj = {
     text: string | string[]
@@ -41,17 +42,12 @@ export function normalizeSep(path: string) {
     return path.replaceAll('\\', '/')
 }
 
-export function globConfToArgs(
-    conf: GlobConf,
-    root: string,
-    localesDir: string,
-    outDir?: string,
-): [string[], { ignore: string[] }] {
+export function globConfToArgs(conf: GlobConf, localesDir: string, outDir?: string): [string[], string[]] {
     let patterns: string[] = []
     // ignore generated files
-    const options = { ignore: [`${localesDir}/**/*`], cwd: root }
+    const ignore = [`${localesDir}/**/*`]
     if (outDir) {
-        options.ignore.push(outDir)
+        ignore.push(outDir)
     }
     if (typeof conf === 'string') {
         patterns = [conf]
@@ -64,12 +60,12 @@ export function globConfToArgs(
             patterns = conf.include
         }
         if (typeof conf.ignore === 'string') {
-            options.ignore.push(conf.ignore)
+            ignore.push(conf.ignore)
         } else {
-            options.ignore.push(...conf.ignore)
+            ignore.push(...conf.ignore)
         }
     }
-    return [patterns.map(normalizeSep), options]
+    return [patterns.map(normalizeSep), ignore]
 }
 
 export async function getLoaderPath(
@@ -149,9 +145,9 @@ export class Files {
         this.#urlsFname = resolve(opts.localesDirAbs, `${opts.key}.url.js`)
     }
 
-    getCompiledFilePath(loc: string, id: string | null) {
+    getCompiledFilePath(loc: string, id: number | null) {
         const ownerKey = this.#opts.ownerKey
-        return resolve(this.#opts.localesDirAbs, generatedDir, `${ownerKey}.${id ?? ownerKey}.${loc}.compiled.js`)
+        return resolve(this.#opts.localesDirAbs, generatedDir, `${ownerKey}.${id ?? defaultLoadID}.${loc}.compiled.js`)
     }
 
     getImportPath(filename: string, importer?: string) {
@@ -164,55 +160,57 @@ export class Files {
     }
 
     // typed to work regardless of user's noUncheckedIndexedAccess setting in tsconfig
-    genProxyContent(catalogs: string[], loadIDs: string[], syncImports?: string[]) {
+    genProxyContent(catalogs: string[], patterns: LoadGroupPatt[], syncImports?: string[]) {
         const baseType = 'import("wuchale/runtime").CatalogModule'
         return `
             ${syncImports?.join('\n') ?? ''}
             /** @typedef {${syncImports ? baseType : `() => Promise<${baseType}>`}} CatalogMod */
             /** @typedef {{[locale: string]: CatalogMod}} KeyCatalogs */
-            /** @type {{[loadID: string]: KeyCatalogs}} */
-            const catalogs = {${catalogs.join(',')}}
-            export const loadCatalog = (/** @type {string} */ loadID, /** @type {string} */ locale) => {
+            /** @type {KeyCatalogs[]} */
+            const catalogs = [${catalogs.join(',')}]
+            export const loadCatalog = (/** @type {number} */ loadID, /** @type {string} */ locale) => {
                 return /** @type {CatalogMod} */ (/** @type {KeyCatalogs} */ (catalogs[loadID])[locale])${syncImports ? '' : '()'}
             }
-            export const loadIDs = ['${loadIDs.join("', '")}']
+            export const nLoadIDs = ${catalogs.length}
+            export const patterns = ${JSON.stringify(patterns)}
         `
     }
 
-    genProxy(locales: string[], loadIDs: string[], loadIDsImport: string[]) {
+    genProxy(locales: string[], patterns: LoadGroupPatt[]) {
         const imports: string[] = []
-        for (const [i, id] of loadIDs.entries()) {
+        for (const [loadID] of patterns.entries()) {
             const importsByLocale: string[] = []
             for (const loc of locales) {
                 importsByLocale.push(
-                    `${objKeyLocale(loc)}: () => import('${this.getImportPath(this.getCompiledFilePath(loc, loadIDsImport[i]!))}')`,
+                    `${objKeyLocale(loc)}: () => import('${this.getImportPath(this.getCompiledFilePath(loc, loadID!))}')`,
                 )
             }
-            imports.push(`${id}: {${importsByLocale.join(',')}}`)
+            imports.push(`{${importsByLocale.join(',')}}`)
         }
-        return this.genProxyContent(imports, loadIDs)
+        return this.genProxyContent(imports, patterns)
     }
 
-    genProxySync(locales: string[], loadIDs: string[], loadIDsImport: string[]) {
+    genProxySync(locales: string[], patterns: LoadGroupPatt[]) {
         const imports: string[] = []
         const object: string[] = []
-        for (const [il, id] of loadIDs.entries()) {
+        for (const [loadID] of patterns.entries()) {
             const importedByLocale: string[] = []
             for (const [i, loc] of locales.entries()) {
-                const locKey = `_w_c_${id}_${i}_`
+                const locKey = `_w_c_${loadID}_${i}_`
                 imports.push(
-                    `import * as ${locKey} from '${this.getImportPath(this.getCompiledFilePath(loc, loadIDsImport[il]!))}'`,
+                    `import * as ${locKey} from '${this.getImportPath(this.getCompiledFilePath(loc, loadID))}'`,
                 )
                 importedByLocale.push(`${objKeyLocale(loc)}: ${locKey}`)
             }
-            object.push(`${id}: {${importedByLocale.join(',')}}`)
+            object.push(`{${importedByLocale.join(',')}}`)
         }
-        return this.genProxyContent(object, loadIDs, imports)
+        return this.genProxyContent(object, patterns, imports)
     }
 
-    writeProxies = async (locales: string[], loadIDs: string[], loadIDsImport: string[]) => {
-        await this.#opts.fs.write(this.#proxyPath, this.genProxy(locales, loadIDs, loadIDsImport))
-        await this.#opts.fs.write(this.#proxySyncPath, this.genProxySync(locales, loadIDs, loadIDsImport))
+    writeProxies = async (locales: string[], groupPatterns: LoadGroupPatt[]) => {
+        const allPatterns: LoadGroupPatt[] = [this.#opts.key, ...groupPatterns]
+        await this.#opts.fs.write(this.#proxyPath, this.genProxy(locales, allPatterns))
+        await this.#opts.fs.write(this.#proxySyncPath, this.genProxySync(locales, allPatterns))
     }
 
     static create = async (opts: FilesOptsCreate) => {
@@ -264,12 +262,12 @@ export class Files {
         await this.#opts.fs.write(this.#urlsFname, urlFileContent)
     }
 
-    getManifestFilePath(id: string | null): string {
+    getManifestFilePath(id: number | null): string {
         const ownerKey = this.#opts.ownerKey
-        return resolve(this.#opts.localesDirAbs, generatedDir, `${ownerKey}.${id ?? ownerKey}.manifest.js`)
+        return resolve(this.#opts.localesDirAbs, generatedDir, `${ownerKey}.${id ?? defaultLoadID}.manifest.js`)
     }
 
-    writeManifest = async (keys: ManifestEntry[], id: string | null) => {
+    writeManifest = async (keys: ManifestEntry[], id: number | null) => {
         const content =
             `/** @type {(string | string[] | {text: string | string[], context?: string, isUrl?: boolean})[]} */\n` +
             `export const keys = ${JSON.stringify(keys)}`
@@ -281,7 +279,7 @@ export class Files {
         pluralRule: string | null,
         locale: string,
         hmrVersion: number | null,
-        loadID: string | null,
+        loadID: number | null,
     ) => {
         const compiledItems = JSON.stringify(compiledData)
         let module = `/** @type import('wuchale').CompiledElement[] */\nexport let c = ${compiledItems}`

--- a/packages/wuchale/src/handler/files.ts
+++ b/packages/wuchale/src/handler/files.ts
@@ -160,51 +160,49 @@ export class Files {
     }
 
     // typed to work regardless of user's noUncheckedIndexedAccess setting in tsconfig
-    genProxyContent(catalogs: string[], patterns: LoadGroupPatt[], syncImports?: string[]) {
+    genProxyContent(catalogs: string[], patterns: LoadGroupPatt[], locales: string[], syncImports?: string[]) {
         const baseType = 'import("wuchale/runtime").CatalogModule'
+        const byLocale = catalogs.map((locCats, i) => `${objKeyLocale(locales[i]!)}: ${locCats}`).join(',')
         return `
             ${syncImports?.join('\n') ?? ''}
             /** @typedef {${syncImports ? baseType : `() => Promise<${baseType}>`}} CatalogMod */
-            /** @typedef {{[locale: string]: CatalogMod}} KeyCatalogs */
-            /** @type {KeyCatalogs[]} */
-            const catalogs = [${catalogs.join(',')}]
+            /** @type {{[locale: string]: CatalogMod[]}} */
+            const catalogs = {${byLocale}}
             export const loadCatalog = (/** @type {number} */ loadID, /** @type {string} */ locale) => {
-                return /** @type {CatalogMod} */ (/** @type {KeyCatalogs} */ (catalogs[loadID])[locale])${syncImports ? '' : '()'}
+                return /** @type {CatalogMod} */ (/** @type {CatalogMod[]} */ (catalogs[locale])[loadID])${syncImports ? '' : '()'}
             }
-            export const nLoadIDs = ${catalogs.length}
+            export const loadCount = ${patterns.length}
             export const patterns = ${JSON.stringify(patterns)}
         `
     }
 
     genProxy(locales: string[], patterns: LoadGroupPatt[]) {
         const imports: string[] = []
-        for (const [loadID] of patterns.entries()) {
-            const importsByLocale: string[] = []
-            for (const loc of locales) {
-                importsByLocale.push(
-                    `${objKeyLocale(loc)}: () => import('${this.getImportPath(this.getCompiledFilePath(loc, loadID!))}')`,
-                )
+        for (const loc of locales) {
+            const importsForLocale: string[] = []
+            for (const [loadID] of patterns.entries()) {
+                importsForLocale.push(`() => import('${this.getImportPath(this.getCompiledFilePath(loc, loadID!))}')`)
             }
-            imports.push(`{${importsByLocale.join(',')}}`)
+            imports.push(`[${importsForLocale.join(',')}]`)
         }
-        return this.genProxyContent(imports, patterns)
+        return this.genProxyContent(imports, patterns, locales)
     }
 
     genProxySync(locales: string[], patterns: LoadGroupPatt[]) {
         const imports: string[] = []
         const object: string[] = []
-        for (const [loadID] of patterns.entries()) {
-            const importedByLocale: string[] = []
-            for (const [i, loc] of locales.entries()) {
+        for (const [i, loc] of locales.entries()) {
+            const importedForLocale: string[] = []
+            for (const [loadID] of patterns.entries()) {
                 const locKey = `_w_c_${loadID}_${i}_`
                 imports.push(
                     `import * as ${locKey} from '${this.getImportPath(this.getCompiledFilePath(loc, loadID))}'`,
                 )
-                importedByLocale.push(`${objKeyLocale(loc)}: ${locKey}`)
+                importedForLocale.push(locKey)
             }
-            object.push(`{${importedByLocale.join(',')}}`)
+            object.push(`[${importedForLocale.join(',')}]`)
         }
-        return this.genProxyContent(object, patterns, imports)
+        return this.genProxyContent(object, patterns, locales, imports)
     }
 
     writeProxies = async (locales: string[], groupPatterns: LoadGroupPatt[]) => {

--- a/packages/wuchale/src/handler/files.ts
+++ b/packages/wuchale/src/handler/files.ts
@@ -172,6 +172,7 @@ export class Files {
                 return /** @type {CatalogMod} */ (/** @type {CatalogMod[]} */ (catalogs[locale])[loadID])${syncImports ? '' : '()'}
             }
             export const loadCount = ${patterns.length}
+            // not essential. in case it is needed and for debugging
             export const patterns = ${JSON.stringify(patterns)}
         `
     }

--- a/packages/wuchale/src/handler/index.test.ts
+++ b/packages/wuchale/src/handler/index.test.ts
@@ -70,7 +70,7 @@ test('HMR', async (t: TestContext) => {
             return _w_rt_
         }
 
-        _w_load_('test')(0)
+        _w_load_()(0)
     `),
     )
     // not on SSR
@@ -78,13 +78,13 @@ test('HMR', async (t: TestContext) => {
         trimLines((await handler.transform(content, 'test.js', 1, true))[0].code),
         trimLines(ts`
         import {getRuntime as _w_load_, getRuntimeRx as _w_load_rx_} from "./src/locales/test.loader.js"
-        _w_load_('test')(0)
+        _w_load_()(0)
     `),
     )
 })
 
 test('Manifest', async (t: TestContext) => {
-    const manifestPath = resolve(import.meta.dirname, defaultConfig.localesDir, generatedDir, 'test.test.manifest.js')
+    const manifestPath = resolve(import.meta.dirname, defaultConfig.localesDir, generatedDir, 'test.0.manifest.js')
     const content = await inMemFS.read(manifestPath)
     t.assert.strictEqual(
         trimLines(content!),

--- a/packages/wuchale/src/handler/index.ts
+++ b/packages/wuchale/src/handler/index.ts
@@ -11,6 +11,7 @@ import type { Logger } from '../log.js'
 import type { HMRData } from '../runtime.js'
 import { type FileRef, type FileRefEntry, type Item, itemIsUrl, newItem } from '../storage.js'
 import {
+    defaultLoadID,
     Files,
     type FilesOptsCreatePass,
     globConfToArgs,
@@ -39,25 +40,18 @@ type TrackedRefs = Map<
     }
 >
 
-/** return two arrays: the corresponding one, and the one to import from in the case of shared catalogs */
-export function getLoadIDs(
-    adapter: Adapter,
-    key: string,
-    ownerKey: string,
-    granularStates: Iterable<GranularState>,
-    sourceLocale: string,
-): [string[], string[]] {
-    const loadIDs: string[] = []
-    if (!adapter.granularLoad) {
-        return [[key], [ownerKey]]
+export function getLoadIDs(adapter: Adapter, granularStates: Iterable<GranularState>, sourceLocale: string): number[] {
+    if (!adapter.loading.granular) {
+        return [defaultLoadID]
     }
+    const loadIDs: number[] = []
     for (const state of granularStates) {
         // only the ones with ready messages
         if (state.compiled.get(sourceLocale)!.items.length) {
             loadIDs.push(state.id)
         }
     }
-    return [loadIDs, loadIDs]
+    return loadIDs
 }
 
 type HandlerOptsCreate = FilesOptsCreatePass & {
@@ -92,9 +86,8 @@ export class AdapterHandler {
         this.adapter = opts.adapter
         this.granularState = opts.granularState
         this.sharedState = opts.sharedState
-        this.fileMatches = pm(
-            ...globConfToArgs(opts.adapter.files, opts.root, opts.config.localesDir, opts.adapter.outDir),
-        )
+        const [patterns, ignore] = globConfToArgs(opts.adapter.files, opts.config.localesDir, opts.adapter.outDir)
+        this.fileMatches = pm(patterns, { ignore })
         this.sourceLocale = opts.sourceLocale
         this.url = new URLHandler(opts.config.locales, this.sourceLocale, opts.adapter.url)
         this.files = opts.files
@@ -118,19 +111,15 @@ export class AdapterHandler {
             fs,
             root,
         })
-        const writeProxies: WriteProxies = states =>
-            files.writeProxies(
-                config.locales,
-                ...getLoadIDs(adapter, key, sharedState.ownerKey, states, opts.sourceLocale),
-            )
-        const granularState = new State(writeProxies, adapter.generateLoadID)
+        const writeProxies: WriteProxies = groupPatts => files.writeProxies(config.locales, groupPatts)
+        const granularState = new State(writeProxies, adapter.loading.group)
         const handler = new AdapterHandler({ ...opts, granularState, files })
         await handler.loadStorage()
         if (await handler.url.initPatterns(key, sharedState.catalog, handler.aiQueue)) {
             await handler.saveStorage()
         }
         await handler.compile()
-        await writeProxies(granularState.byID.values())
+        await writeProxies(granularState.groupPatterns)
         await files.writeUrlFiles(handler.url.buildManifest(sharedState.catalog), config.locales[0])
         return handler
     }
@@ -181,7 +170,7 @@ export class AdapterHandler {
 
     #writeManifests = async () => {
         const promises = [this.files.writeManifest(this.#buildManifest(this.sharedState.indexTracker.indices), null)]
-        if (this.adapter.granularLoad) {
+        if (this.adapter.loading.granular) {
             for (const state of this.granularState.byID.values()) {
                 promises.push(this.files.writeManifest(this.#buildManifest(state.indexTracker.indices), state.id))
             }
@@ -207,7 +196,7 @@ export class AdapterHandler {
                 null,
             ),
         ]
-        if (this.adapter.granularLoad) {
+        if (this.adapter.loading.granular) {
             for (const state of this.granularState.byID.values()) {
                 compiledData = state.compiled?.get(loc) || {
                     hasPlurals: false,
@@ -292,7 +281,7 @@ export class AdapterHandler {
                     compiled = compileTranslation(toCompile, fallback)
                 }
                 sharedCompiledLoc.items[index] = compiled
-                if (!this.adapter.granularLoad) {
+                if (!this.adapter.loading.granular) {
                     continue
                 }
                 for (const ref of item.references) {
@@ -324,7 +313,7 @@ export class AdapterHandler {
 
     #prepareHeader = (
         filename: string,
-        loadID: string,
+        loadID: number,
         hmrData: HMRData | null,
         hasUrls: boolean,
         forServer: boolean,
@@ -362,7 +351,7 @@ export class AdapterHandler {
             `${loaderImportGetRuntimeRx} as ${getRuntimeReactive}`,
         ]
         head = [`import {${importsFuncs.join(', ')}} from "${loaderPath}"`, ...head]
-        if (!this.adapter.bundleLoad) {
+        if (!this.adapter.loading.direct) {
             return head.join('\n')
         }
         const imports: string[] = []
@@ -376,17 +365,19 @@ export class AdapterHandler {
         return [...imports, ...head, `const ${bundleCatalogsVarName} = {${objElms.join(',')}}`].join('\n')
     }
 
-    #prepareRuntimeExpr = (loadID: string): RuntimeExpr => {
+    #prepareRuntimeExpr = (loadID: number): RuntimeExpr => {
         const importLoaderVars = this.#getRuntimeVars()
-        if (this.adapter.bundleLoad) {
+        if (this.adapter.loading.direct) {
             return {
                 plain: `${importLoaderVars.plain}(${bundleCatalogsVarName})`,
                 reactive: `${importLoaderVars.reactive}(${bundleCatalogsVarName})`,
             }
         }
+        // default is always 0 unless loading.granular is true
+        const loadIDParam = loadID === 0 ? '' : loadID
         return {
-            plain: `${importLoaderVars.plain}('${loadID}')`,
-            reactive: `${importLoaderVars.reactive}('${loadID}')`,
+            plain: `${importLoaderVars.plain}(${loadIDParam})`,
+            reactive: `${importLoaderVars.reactive}(${loadIDParam})`,
         }
     }
 
@@ -536,9 +527,9 @@ export class AdapterHandler {
     ): Promise<[TransformOutputCode, boolean]> => {
         filename = normalizeSep(filename)
         let indexTracker = this.sharedState.indexTracker
-        let loadID = this.key
+        let loadID = defaultLoadID
         let compiled = this.sharedState.compiled
-        if (this.adapter.granularLoad) {
+        if (this.adapter.loading.granular) {
             const state = await this.granularState.byFileCreate(filename, this.#opts.config.locales)
             indexTracker = state.indexTracker
             loadID = state.id

--- a/packages/wuchale/src/handler/state.ts
+++ b/packages/wuchale/src/handler/state.ts
@@ -1,4 +1,5 @@
-import { getKey, IndexTracker } from '../adapters.js'
+import pm from 'picomatch'
+import { getKey, IndexTracker, type LoadGroupPatt } from '../adapters.js'
 import type { CompiledElement } from '../compile.js'
 import { type Catalog, type CatalogStorage, defaultPluralRule, fillTranslations, type PluralRules } from '../storage.js'
 
@@ -78,54 +79,65 @@ export class SharedState {
 }
 
 export type GranularState = {
-    id: string
+    id: number
     compiled: CompiledCatalogs
     indexTracker: IndexTracker
 }
 
-export type WriteProxies = (states: Iterable<GranularState>) => Promise<void>
+export type WriteProxies = (groupPatterns: LoadGroupPatt[]) => Promise<void>
 
 export class State {
-    byFile: Map<string, GranularState> = new Map()
-    byID: Map<string, GranularState> = new Map()
+    #byFile: Map<string, GranularState> = new Map()
+    readonly byID: Map<number, GranularState> = new Map()
 
-    writeProxies: WriteProxies
-    generateLoadID: (filename: string) => string
+    #writeProxies: WriteProxies
+    readonly groupPatterns: LoadGroupPatt[] = []
+    #groupMatches: ((f: string) => boolean)[] = []
 
-    constructor(writeProxies: WriteProxies, generateLoadID: (filename: string) => string) {
-        this.writeProxies = writeProxies
-        this.generateLoadID = generateLoadID
+    constructor(writeProxies: WriteProxies, groupPatterns: LoadGroupPatt[]) {
+        this.#writeProxies = writeProxies
+        this.groupPatterns = groupPatterns
+        this.#groupMatches = groupPatterns.map(p => pm(p))
+    }
+
+    #getLoadID(filename: string) {
+        let id = -1
+        for (const [i, match] of this.#groupMatches.entries()) {
+            if (!match(filename)) {
+                continue
+            }
+            id = i
+        }
+        if (id === -1) {
+            id = this.groupPatterns.length
+            this.groupPatterns.push(filename)
+            this.#groupMatches.push(f => f === filename)
+        }
+        return id + 1 // not to start from 0 which is reserved for the shared
     }
 
     async byFileCreate(filename: string, locales: string[]): Promise<GranularState> {
-        let state = this.byFile.get(filename)
+        let state = this.#byFile.get(filename)
         if (state != null) {
             return state
         }
-        const id = this.generateLoadID(filename)
+        const id = this.#getLoadID(filename)
         const stateG = this.byID.get(id)
         if (stateG) {
             state = stateG
         } else {
-            const compiledLoaded: Map<string, Compiled> = new Map()
             state = {
                 id,
                 compiled: new Map(),
                 indexTracker: new IndexTracker(),
             }
             for (const loc of locales) {
-                state.compiled.set(
-                    loc,
-                    compiledLoaded.get(loc) ?? {
-                        hasPlurals: false,
-                        items: [],
-                    },
-                )
+                state.compiled.set(loc, { hasPlurals: false, items: [] })
             }
             this.byID.set(id, state)
-            await this.writeProxies(this.byID.values())
+            await this.#writeProxies(this.groupPatterns)
         }
-        this.byFile.set(filename, state)
+        this.#byFile.set(filename, state)
         return state
     }
 }

--- a/packages/wuchale/src/handler/state.ts
+++ b/packages/wuchale/src/handler/state.ts
@@ -122,10 +122,8 @@ export class State {
             return state
         }
         const id = this.#getLoadID(filename)
-        const stateG = this.byID.get(id)
-        if (stateG) {
-            state = stateG
-        } else {
+        state = this.byID.get(id)
+        if (!state) {
             state = {
                 id,
                 compiled: new Map(),

--- a/packages/wuchale/src/hub.test.ts
+++ b/packages/wuchale/src/hub.test.ts
@@ -44,7 +44,7 @@ test('hub transform basic', async (t: TestContext) => {
         trimLines(output.code),
         trimLines(ts`
             import {getRuntime as _w_load_, getRuntimeRx as _w_load_rx_} from "./locales/main.loader.js"
-            _w_load_('main')(0)
+            _w_load_()(0)
         `),
     )
 })
@@ -56,7 +56,7 @@ test('hub transform ssr', async (t: TestContext) => {
         trimLines(output.code),
         trimLines(ts`
         import {getRuntime as _w_load_, getRuntimeRx as _w_load_rx_} from "./locales/main.loader.server.js"
-        _w_load_('main')(0)
+        _w_load_()(0)
     `),
     )
 })
@@ -69,9 +69,7 @@ test('hub onFileChange', async (t: TestContext) => {
     t.assert.deepEqual(res2?.sourceTriggered, false)
     t.assert.partialDeepStrictEqual(
         new Set([
-            normalizeSep(
-                resolve(import.meta.dirname, defaultConfig.localesDir, generatedDir, 'main.main.en.compiled.js'),
-            ),
+            normalizeSep(resolve(import.meta.dirname, defaultConfig.localesDir, generatedDir, 'main.0.en.compiled.js')),
         ]),
         res2?.invalidate,
     )
@@ -94,7 +92,7 @@ test('hub transform with hmr', async (t: TestContext) => {
             _w_rt_?._?.update?.(_w_hmrUpdate_)
             return _w_rt_
         }
-        _w_load_('main')(0)
+        _w_load_()(0)
     `),
     )
 })

--- a/packages/wuchale/src/hub.ts
+++ b/packages/wuchale/src/hub.ts
@@ -161,7 +161,7 @@ export class Hub {
                 this.#lastSourceTriggeredCatalogWrite = performance.now()
             }
             const adapter = handler.adapter
-            if (adapter.granularLoad) {
+            if (adapter.loading.granular) {
                 this.#granularLoadHandlers.push(handler)
             } else {
                 for (const locale of opts.config.locales) {
@@ -284,13 +284,7 @@ export class Hub {
                 await handler.loadStorage()
                 await handler.compile(this.#hmrVersion)
             }
-            const [loadIDs] = getLoadIDs(
-                handler.adapter,
-                handler.key,
-                handler.sharedState.ownerKey,
-                handler.granularState.byID.values(),
-                handler.sourceLocale,
-            )
+            const loadIDs = getLoadIDs(handler.adapter, handler.granularState.byID.values(), handler.sourceLocale)
             for (const loc of this.#opts.config.locales) {
                 for (const loadID of loadIDs) {
                     changeInfo.invalidate.add(normalizeSep(handler.files.getCompiledFilePath(loc, loadID)))
@@ -338,14 +332,12 @@ export class Hub {
         sync: boolean,
         existingFilesByOwner: Map<string, Set<string>>,
     ): Promise<boolean> {
-        const filePaths = await glob(
-            ...globConfToArgs(
-                handler.adapter.files,
-                this.#opts.root,
-                this.#opts.config.localesDir,
-                handler.adapter.outDir,
-            ),
+        const [patterns, ignore] = globConfToArgs(
+            handler.adapter.files,
+            this.#opts.config.localesDir,
+            handler.adapter.outDir,
         )
+        const filePaths = await glob(patterns, { ignore, cwd: this.#opts.root })
         let existingFiles = existingFilesByOwner.get(handler.sharedState.ownerKey)
         if (existingFiles) {
             for (const file of filePaths) {

--- a/packages/wuchale/src/hub.ts
+++ b/packages/wuchale/src/hub.ts
@@ -86,7 +86,7 @@ async function initGenDirWithData(config: Config, fs: FS, root: string) {
         resolve(localesDirAbs, dataFileName),
         [
             `/** @typedef {('${config.locales.join("'|'")}')} Locale */`,
-            `/** @type {Locale[]} */`,
+            `/** @type {[Locale, ...Locale[]]} */`,
             `export const locales = ['${config.locales.join("','")}']`,
         ].join('\n'),
     )

--- a/packages/wuchale/src/index.ts
+++ b/packages/wuchale/src/index.ts
@@ -10,6 +10,7 @@ export type {
     HeuristicFunc,
     HeuristicResult,
     LoaderChoice,
+    LoadGroupPatt,
     Message,
     MessageType,
     RuntimeConf,
@@ -21,7 +22,6 @@ export type {
 } from './adapters.js'
 export {
     createHeuristic,
-    defaultGenerateLoadID,
     defaultHeuristic,
     defaultHeuristicOpts,
     getKey,

--- a/packages/wuchale/src/load-utils/index.test.ts
+++ b/packages/wuchale/src/load-utils/index.test.ts
@@ -11,20 +11,20 @@ import { loadLocales, runWithLocale } from './server.js'
 const loaderFunc = () => testCatalog
 
 test('Loading', async t => {
-    const collection: Record<string, Runtime> = {}
-    const getRT = registerLoaders('main', loaderFunc, ['foo'], defaultCollection(collection))
+    const collection: Runtime[] = []
+    const getRT = registerLoaders('main', loaderFunc, 1, defaultCollection(collection))
     loadLocaleSync('en')
-    t.assert.notEqual(collection['foo'], null) // setCatalogs was called
-    const rt = getRT('foo')
+    t.assert.notEqual(collection[0], null) // setCatalogs was called
+    const rt = getRT()
     t.assert.equal(rt.l, 'en')
-    const cPure = await loadCatalogs('en', ['foo'], loaderFunc)
-    t.assert.equal(cPure['foo']!.c[0], 'Hello')
+    const cPure = await loadCatalogs('en', [0], loaderFunc)
+    t.assert.equal(cPure[0]!.c[0], 'Hello')
 })
 
 test('Loading server side', async t => {
-    const getRT = await loadLocales('main', ['main'], _ => testCatalog, ['en'])
+    const getRT = await loadLocales('main', 1, _ => testCatalog, ['en'])
     const msg = await runWithLocale('en', () => {
-        return getRT('main')(1, ['server user'])
+        return getRT()(1, ['server user'])
     })
     t.assert.equal(msg, 'Hello server user!')
 })

--- a/packages/wuchale/src/load-utils/index.ts
+++ b/packages/wuchale/src/load-utils/index.ts
@@ -1,19 +1,19 @@
 import toRuntime, { type CatalogModule, type Runtime } from '../runtime.js'
 
-export type LoaderFunc = (loadID: string, locale: string) => CatalogModule | Promise<CatalogModule>
+export type LoaderFunc = (loadID: number, locale: string) => CatalogModule | Promise<CatalogModule>
 
 export type RuntimeCollection = {
-    get: (loadID: string) => Runtime
-    set: (loadID: string, catalog: Runtime) => void
+    get: (loadID: number) => Runtime
+    set: (loadID: number, runtime: Runtime) => void
 }
 
 export type LoaderState = {
     load: LoaderFunc
-    catalogs: { [loadID: string]: CatalogModule | undefined }
+    catalogs: (CatalogModule | undefined)[]
     collection: RuntimeCollection
 }
 
-export function defaultCollection(store: Record<string, Runtime>): RuntimeCollection {
+export function defaultCollection(store: Runtime[]): RuntimeCollection {
     return {
         get: loadID => store[loadID]!,
         set: (loadID, rt) => {
@@ -33,24 +33,24 @@ const emptyRuntime = toRuntime()
 export function registerLoaders(
     key: string,
     load: LoaderFunc,
-    loadIDs: string[],
+    nLoadIDs: number,
     collection?: RuntimeCollection,
-): (fileID: string) => Runtime {
+): (loadID?: number) => Runtime {
     states[key] = {
         load,
-        catalogs: Object.fromEntries(loadIDs.map(id => [id])),
-        collection: collection ?? defaultCollection({}),
+        catalogs: Array(nLoadIDs).fill(undefined),
+        collection: collection ?? defaultCollection([]),
     }
-    for (const id of loadIDs) {
+    for (let id = 0; id < nLoadIDs; id++) {
         states[key].collection.set(id, emptyRuntime)
     }
-    return loadID => states[key]!.collection.get(loadID)
+    return (loadID = 0) => states[key]!.collection.get(loadID)
 }
 
 /* Sets the most recently loaded locale as the current one */
 export function commitLocale(locale: string) {
     for (const state of Object.values(states)) {
-        for (const [loadID, catalog] of Object.entries(state.catalogs)) {
+        for (const [loadID, catalog] of state.catalogs.entries()) {
             state.collection.set(loadID, toRuntime(catalog, locale))
         }
     }
@@ -63,11 +63,11 @@ export function commitLocale(locale: string) {
  */
 export async function loadLocale(locale: string, commit = true): Promise<void> {
     const promises: Promise<CatalogModule>[] = []
-    const statesArr: [string, LoaderState][] = []
+    const statesArr: [number, LoaderState][] = []
     for (const state of Object.values(states)) {
-        for (const loadID of Object.keys(state.catalogs)) {
-            promises.push(state.load(loadID, locale) as Promise<CatalogModule>)
-            statesArr.push([loadID, state])
+        for (let id = 0; id < state.catalogs.length; id++) {
+            promises.push(state.load(id, locale) as Promise<CatalogModule>)
+            statesArr.push([id, state])
         }
     }
     for (const [i, loaded] of (await Promise.all(promises)).entries()) {
@@ -85,8 +85,8 @@ export async function loadLocale(locale: string, commit = true): Promise<void> {
  */
 export function loadLocaleSync(locale: string, commit = true) {
     for (const state of Object.values(states)) {
-        for (const loadID of Object.keys(state.catalogs)) {
-            state.catalogs[loadID] = state.load(loadID, locale) as CatalogModule
+        for (let id = 0; id < state.catalogs.length; id++) {
+            state.catalogs[id] = state.load(id, locale) as CatalogModule
         }
     }
     commit && commitLocale(locale)

--- a/packages/wuchale/src/load-utils/index.ts
+++ b/packages/wuchale/src/load-utils/index.ts
@@ -33,15 +33,15 @@ const emptyRuntime = toRuntime()
 export function registerLoaders(
     key: string,
     load: LoaderFunc,
-    nLoadIDs: number,
+    loadCount: number,
     collection?: RuntimeCollection,
 ): (loadID?: number) => Runtime {
     states[key] = {
         load,
-        catalogs: Array(nLoadIDs).fill(undefined),
+        catalogs: Array(loadCount).fill(undefined),
         collection: collection ?? defaultCollection([]),
     }
-    for (let id = 0; id < nLoadIDs; id++) {
+    for (let id = 0; id < loadCount; id++) {
         states[key].collection.set(id, emptyRuntime)
     }
     return (loadID = 0) => states[key]!.collection.get(loadID)

--- a/packages/wuchale/src/load-utils/pure.ts
+++ b/packages/wuchale/src/load-utils/pure.ts
@@ -1,10 +1,10 @@
 import type { CatalogModule } from '../runtime.js'
 import type { LoaderFunc } from './index.js'
 
-export type CatalogsByID = Record<string, CatalogModule>
+export type CatalogsByID = Record<number, CatalogModule>
 
 /** No-side effect way to load catalogs. Can be used for multiple file IDs. */
-export async function loadCatalogs(locale: string, loadIDs: string[], loadCatalog: LoaderFunc): Promise<CatalogsByID> {
+export async function loadCatalogs(locale: string, loadIDs: number[], loadCatalog: LoaderFunc): Promise<CatalogsByID> {
     const data: CatalogsByID = {}
     const promises = loadIDs.map(id => loadCatalog(id, locale))
     // merge into one object

--- a/packages/wuchale/src/load-utils/server.ts
+++ b/packages/wuchale/src/load-utils/server.ts
@@ -3,7 +3,7 @@ import toRuntime, { type Runtime } from '../runtime.js'
 import type { LoaderFunc } from './index.js'
 
 // by key, by loadID
-type LoadedRuntimes = Record<string, Record<string, Runtime>>
+type LoadedRuntimes = Record<string, Runtime[]>
 // by locale
 const runtimes: Record<string, LoadedRuntimes> = {}
 // exported mainly for stackblitz examples polyfills
@@ -12,7 +12,7 @@ const emptyRuntime = toRuntime()
 
 const warningShown: Record<string, boolean> = {}
 
-export function currentRuntime(key: string, loadID: string) {
+export function currentRuntime(key: string, loadID: number) {
     const runtime = runtimeCtx.getStore()?.[key]?.[loadID]
     if (runtime != null) {
         return runtime
@@ -30,26 +30,23 @@ export function currentRuntime(key: string, loadID: string) {
 
 export async function loadLocales(
     key: string,
-    loadIDs: string[],
+    nLoadIDs: number,
     load: LoaderFunc,
     locales: string[],
-): Promise<(loadID: string) => Runtime> {
-    if (loadIDs == null) {
-        loadIDs = [key]
-    }
+): Promise<(loadID?: number) => Runtime> {
     for (const locale of locales) {
         if (!(locale in runtimes)) {
             runtimes[locale] = {}
         }
         const loaded = runtimes[locale]!
         if (!(key in loaded)) {
-            loaded[key] = {}
+            loaded[key] = []
         }
-        for (const id of loadIDs) {
+        for (let id = 0; id < nLoadIDs; id++) {
             loaded[key]![id] = toRuntime(await load(id, locale), locale)
         }
     }
-    return (loadID: string) => currentRuntime(key, loadID)
+    return (loadID = 0) => currentRuntime(key, loadID)
 }
 
 export async function runWithLocale<T>(locale: string, func: () => T): Promise<T> {

--- a/packages/wuchale/src/load-utils/server.ts
+++ b/packages/wuchale/src/load-utils/server.ts
@@ -30,7 +30,7 @@ export function currentRuntime(key: string, loadID: number) {
 
 export async function loadLocales(
     key: string,
-    nLoadIDs: number,
+    loadCount: number,
     load: LoaderFunc,
     locales: string[],
 ): Promise<(loadID?: number) => Runtime> {
@@ -42,7 +42,7 @@ export async function loadLocales(
         if (!(key in loaded)) {
             loaded[key] = []
         }
-        for (let id = 0; id < nLoadIDs; id++) {
+        for (let id = 0; id < loadCount; id++) {
             loaded[key]![id] = toRuntime(await load(id, locale), locale)
         }
     }


### PR DESCRIPTION
With the current implementation, the load IDs are strings and if granular loading is enabled, a load ID generator function is used, which may allow collisions and it would need hashing to avoid/reduce collisions, also makes file names long, and contributes (just a little) to bundle size inflation by having `_w_load_('some_long_load_id')` and this makes it seem the wrong solution.

This PR uses arrays and index numbers just like for the messages, so the file names will be shorter, the loading code will be shorter like `_w_load_(2)` and the config will be easier removing the need to name anything, just use glob patterns to indicate grouping and if a file doesn't belong to a group, it will have its own group where it is the only member.