### PR TITLE
Built-in URL matching algorithm

### DIFF
--- a/.changeset/wicked-doors-wait.md
+++ b/.changeset/wicked-doors-wait.md
@@ -1,0 +1,31 @@
+---
+"wuchale": minor
+---
+
+⚠️ BREAKING: Built-in URL matcher
+
+A small purpose-built no-RegExp URL matcher is now included and the glob-like syntax it accepts is different from/simpler than that of `path-to-regexp`.
+
+- `*` for required segments like `/foo-*` matches `/foo-bar`
+- `?` for optional segments like `/foo/?` matches `/foo` and `/foo/bar`
+- `**` for nested like `/foo/**` matches `/foo`, `/foo/bar` and `/foo/1/bar`
+
+If you use URL patterns, you have to adjust your config accordingly:
+
+```diff
+export default {
+    // ...
+    adapters: {
+        main: svelte({
+            // ...
+            url: {
+                // ...
+                patterns: [
+-                   'foo/*rest',
++                   'foo/**',
+                ]
+            },
+        }),
+    }
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1386,16 +1386,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/path-to-regexp": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
-            "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/express"
-            }
-        },
         "node_modules/path-type": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -1886,7 +1876,7 @@
             "version": "0.3.2",
             "license": "MIT",
             "dependencies": {
-                "@astrojs/compiler": "^4.0.0",
+                "@astrojs/compiler": "^4",
                 "@sveltejs/acorn-typescript": "^1.0.9",
                 "acorn": "^8.16.0",
                 "magic-string": "^0.30.21",
@@ -2017,7 +2007,6 @@
                 "acorn": "^8.16.0",
                 "chokidar": "^5.0.0",
                 "magic-string": "^0.30.21",
-                "path-to-regexp": "^8.4.0",
                 "picomatch": "^4.0.4",
                 "pofile": "^1.1.4",
                 "tinyglobby": "^0.2.16"

--- a/packages/svelte/src/transformer.test.ts
+++ b/packages/svelte/src/transformer.test.ts
@@ -8,9 +8,10 @@ import { defaultArgs, svelteKitDefaultHeuristic } from './index.js'
 import { SvelteTransformer } from './transformer.js'
 
 const urlHandler = new URLHandler(['en'], 'en', {
-    patterns: ['/translated/*rest', '/'],
+    patterns: ['/translated/**', '/'],
     localize: true,
 })
+urlHandler.initPatterns('foo', new Map())
 
 const catalogExpr = { plain: '_w_load_()', reactive: '_w_load_rx_()' }
 

--- a/packages/wuchale/package.json
+++ b/packages/wuchale/package.json
@@ -88,7 +88,6 @@
         "acorn": "^8.16.0",
         "chokidar": "^5.0.0",
         "magic-string": "^0.30.21",
-        "path-to-regexp": "^8.4.0",
         "picomatch": "^4.0.4",
         "pofile": "^1.1.4",
         "tinyglobby": "^0.2.16"

--- a/packages/wuchale/src/adapters.ts
+++ b/packages/wuchale/src/adapters.ts
@@ -175,7 +175,7 @@ export type RuntimeExpr = {
     reactive: string
 }
 
-export type UrlMatcher = (url: string) => string | null | undefined
+export type UrlMatcher = (url: string) => readonly [number, string[]] | null
 
 type TransformCtx = {
     content: string

--- a/packages/wuchale/src/handler/index.ts
+++ b/packages/wuchale/src/handler/index.ts
@@ -120,7 +120,7 @@ export class AdapterHandler {
         }
         await handler.compile()
         await writeProxies(granularState.groupPatterns)
-        await files.writeUrlFiles(handler.url.buildManifest(sharedState.catalog), config.locales[0])
+        await files.writeUrlFiles(handler.url.buildManifest(), config.locales[0])
         return handler
     }
 
@@ -276,7 +276,7 @@ export class AdapterHandler {
                 } else {
                     let toCompile = transl[0]!
                     if (itemIsUrl(item)) {
-                        toCompile = this.url.matchToCompile(key, this.sharedState.catalog, loc)
+                        toCompile = this.url.matchToCompile(key, loc)
                     }
                     compiled = compileTranslation(toCompile, fallback)
                 }
@@ -463,7 +463,7 @@ export class AdapterHandler {
                     ;(err as any).id = filename
                     throw err
                 }
-                key = this.url.patternKeys.get(matched)! // ! because already checked at extraction
+                key = getKey([this.url.patterns[matched[0]]!])
             }
             let item = this.sharedState.catalog.get(key)
             if (!item) {

--- a/packages/wuchale/src/handler/url.test.ts
+++ b/packages/wuchale/src/handler/url.test.ts
@@ -1,6 +1,14 @@
 // $ node --import ../../testing/resolve.ts %f
 
-// import { test } from 'node:test'
-//
-// test('Pattern to/fro', t => {
-// })
+import { type TestContext, test } from 'node:test'
+import { URLHandler } from './url.js'
+
+const handler = new URLHandler(['en'], 'en', {
+    patterns: ['/bar/*'],
+})
+handler.initPatterns('foo', new Map())
+
+test('URL pattern match', (t: TestContext) => {
+    t.assert.deepStrictEqual(handler.match('/bar/foo'), [0, ['/foo']])
+    t.assert.deepStrictEqual(handler.matchToCompile('/bar/foo-{0}', 'en'), '/bar/foo-{0}')
+})

--- a/packages/wuchale/src/handler/url.test.ts
+++ b/packages/wuchale/src/handler/url.test.ts
@@ -1,17 +1,6 @@
 // $ node --import ../../testing/resolve.ts %f
 
-import { test } from 'node:test'
-import { patternFromTranslate, patternToTranslate } from './url.js'
-
-test('Pattern to/fro', t => {
-    t.assert.equal(patternToTranslate('/foo/*rest'), '/foo/{0}')
-    t.assert.equal(patternToTranslate('/foo/:bar/baz{/*rest}'), '/foo/{0}/baz/{1}')
-    t.assert.equal(patternFromTranslate('/foo/{0}/baz', [{ name: 'bar', type: 'param' }]), '/foo/:bar/baz')
-    t.assert.equal(
-        patternFromTranslate('/foo/{0}/{1}', [
-            { name: 'bar', type: 'param' },
-            { name: 'rest', type: 'wildcard' },
-        ]),
-        '/foo/:bar/*rest',
-    )
-})
+// import { test } from 'node:test'
+//
+// test('Pattern to/fro', t => {
+// })

--- a/packages/wuchale/src/handler/url.ts
+++ b/packages/wuchale/src/handler/url.ts
@@ -1,45 +1,14 @@
-import {
-    compile as compileUrlPattern,
-    match as matchUrlPattern,
-    pathToRegexp,
-    stringify,
-    type Token,
-} from 'path-to-regexp'
-import { getKey, type URLConf } from '../adapters.js'
+import { isDeepStrictEqual } from 'node:util'
+import { getKey, type URLConf, type UrlMatcher } from '../adapters.js'
 import type AIQueue from '../ai/index.js'
-import { compileTranslation, type Mixed } from '../compile.js'
 import { type Catalog, type Item, newItem } from '../storage.js'
-import type { URLManifest } from '../url.js'
-
-export function patternFromTranslate(patternTranslated: string, keys: Token[]) {
-    const compiledTranslatedPatt = compileTranslation(patternTranslated, patternTranslated)
-    if (typeof compiledTranslatedPatt === 'string') {
-        return compiledTranslatedPatt
-    }
-    const urlTokens: Token[] = (compiledTranslatedPatt as Mixed).map(part => {
-        if (typeof part === 'number') {
-            return keys[part]!
-        }
-        return { type: 'text', value: part }
-    })
-    return stringify({ tokens: urlTokens })
-}
-
-export function patternToTranslate(pattern: string) {
-    const { keys } = pathToRegexp(pattern)
-    const compile = compileUrlPattern(pattern, { encode: false })
-    const paramsReplace: Record<string, string> = {}
-    for (const [i, { name }] of keys.entries()) {
-        paramsReplace[name] = `{${i}}`
-    }
-    return compile(paramsReplace)
-}
+import { compilePattern, matchPattern, type Pattern, stringifyPattern, type URLManifest } from '../url.js'
 
 export class URLHandler {
-    patternKeys: Map<string, string> = new Map()
-    locales: string[]
-    sourceLocale: string
-    patterns: string[] = []
+    readonly locales: string[]
+    readonly sourceLocale: string
+    readonly patterns: string[] = []
+    readonly compiledPatterns: Map<string, Pattern>[] = []
 
     constructor(locales: string[], sourceLocale: string, urlConf?: URLConf) {
         this.locales = locales
@@ -49,44 +18,34 @@ export class URLHandler {
         }
     }
 
-    buildManifest = (catalog: Catalog): URLManifest =>
+    buildManifest = (): URLManifest => {
         // order of catalogs should be based on locales
-        this.patterns.map(patt => {
-            const catalogPattKey = this.patternKeys.get(patt)!
-            const { keys } = pathToRegexp(patt)
-            const locPatterns: string[] = []
-            const item = catalog.get(catalogPattKey)
+        const manifest: URLManifest = []
+        for (let i = 0; i < this.patterns.length; i++) {
+            const locPatterns: Pattern[] = []
+            const compiledPatts = this.compiledPatterns[i]!
+            const compiledPattBase = compiledPatts.get(this.sourceLocale)!
             for (const loc of this.locales) {
-                let pattern = patt
-                const transl = item?.translations?.get(loc)
-                if (transl) {
-                    const patternTranslated = transl[0]! || item!.translations.get(this.sourceLocale)![0]!
-                    pattern = patternFromTranslate(patternTranslated, keys)
-                }
-                locPatterns.push(pattern)
+                const locCompiledPatt = compiledPatts.get(loc)!
+                locPatterns.push(locCompiledPatt)
             }
-            if (locPatterns.some(p => p !== patt)) {
-                return [patt, locPatterns]
-            }
-            return [patt]
-        })
+            const notAllSame = locPatterns.some(p => !isDeepStrictEqual(p, compiledPattBase))
+            manifest.push(notAllSame ? [compiledPattBase, locPatterns] : [compiledPattBase])
+        }
+        return manifest
+    }
 
     initPatterns = async (adapterKey: string, catalog: Catalog, aiQueue?: AIQueue): Promise<boolean> => {
-        const urlPatternsForTranslate = this.patterns.map(patternToTranslate)
         const urlPatternCatKeys: string[] = []
         const toTranslate: Item[] = []
         let needWriteCatalog = false
-        for (const [i, locPattern] of urlPatternsForTranslate.entries()) {
-            let context: string | undefined
-            if (locPattern !== this.patterns[i]) {
-                context = `original: ${this.patterns[i]}`
-            }
-            const key = getKey([locPattern], context)
+        const toCompile: Item[] = []
+        for (const [i, pattern] of this.patterns.entries()) {
+            const key = getKey([pattern])
             urlPatternCatKeys[i] = key
-            this.patternKeys.set(this.patterns[i]!, key) // save for href translate
             let item = catalog.get(key)
             if (!item) {
-                item = newItem({ id: [locPattern], context }, this.locales)
+                item = newItem({ id: [pattern] }, this.locales)
                 catalog.set(key, item)
                 needWriteCatalog = true
             }
@@ -94,11 +53,12 @@ export class URLHandler {
                 item.urlAdapters.push(adapterKey)
                 needWriteCatalog = true
             }
-            item.translations.set(this.sourceLocale, [locPattern])
-            if (locPattern.search(/\p{L}/u) === -1) {
+            item.translations.set(this.sourceLocale, [pattern])
+            toCompile.push(item)
+            if (pattern.search(/\p{L}/u) === -1) {
                 for (const loc of this.locales) {
                     if (loc !== this.sourceLocale) {
-                        item.translations.set(loc, [locPattern])
+                        item.translations.set(loc, [pattern])
                     }
                 }
                 continue
@@ -117,44 +77,39 @@ export class URLHandler {
             aiQueue.add(toTranslate)
             await aiQueue.running
         }
+        // for matching hrefs
+        for (const item of toCompile) {
+            const compiled = new Map<string, Pattern>()
+            for (const loc of this.locales) {
+                compiled.set(loc, compilePattern(item.translations.get(loc)![0]!))
+            }
+            this.compiledPatterns.push(compiled)
+        }
         return needWriteCatalog
     }
 
-    match = (url: string) => {
-        for (const pattern of this.patterns) {
-            if (matchUrlPattern(pattern, { decode: false })(url)) {
-                return pattern
+    match: UrlMatcher = (url: string) => {
+        for (const [i, pattern] of this.compiledPatterns.entries()) {
+            const dynamics = matchPattern(pattern.get(this.sourceLocale)!, url)
+            if (dynamics) {
+                return [i, dynamics] as const
             }
         }
         return null
     }
 
-    matchToCompile = (key: string, catalog: Catalog, locale: string) => {
+    matchToCompile = (key: string, locale: string) => {
         // e.g. key: /items/foo/{0}
         const toCompile = key
         const relevantPattern = this.match(key)
         if (relevantPattern == null) {
             return toCompile
         }
-        // e.g. relevantPattern: /items/:rest
-        const patternItem = catalog.get(this.patternKeys.get(relevantPattern)!)
-        if (!patternItem) {
-            return toCompile
-        }
-        // e.g. patternItem.id: /items/{0}
-        const matchedUrl = matchUrlPattern(relevantPattern, { decode: false })(key)
-        // e.g. matchUrl.params: {rest: 'foo/{0}'}
-        if (!matchedUrl) {
-            return toCompile
-        }
-        const translatedPattern =
-            patternItem.translations.get(locale)![0] || patternItem.translations.get(this.sourceLocale)![0]!
-        // e.g. translatedPattern: /elementos/{0}
-        const { keys } = pathToRegexp(relevantPattern)
-        const translatedPattUrl = patternFromTranslate(translatedPattern, keys)
-        // e.g. translatedPattUrl: /elementos/:rest
-        const compileTranslated = compileUrlPattern(translatedPattUrl, { encode: false })
-        return compileTranslated(matchedUrl.params)
-        // e.g. return /elementos/foo/{0}
+        // e.g. relevantPattern: [index of /items/**, [foo/{0}]]
+        const [i, dynamics] = relevantPattern
+        const translatedCompiled = this.compiledPatterns[i]!.get(locale)!
+        // e.g. translatedCompiled: [/elementos, 0]
+        return stringifyPattern(translatedCompiled, dynamics)
+        // e.g. /elementos/foo/{0}
     }
 }

--- a/packages/wuchale/src/url.test.ts
+++ b/packages/wuchale/src/url.test.ts
@@ -1,7 +1,79 @@
 // $ node --import ../testing/resolve.ts %f
 
 import { test } from 'node:test'
-import { URLMatcher } from './url.js'
+import { compilePattern, matchPattern, URLMatcher } from './url.js'
+
+const cases = [
+    // Exact (no wildcards)
+    ['/foo/bar', '/foo/bar', true],
+    ['/foo/bar', '/foo/baz', false],
+    ['/foo/bar', '/foo/bar/baz', false],
+
+    // * within segment
+    ['/foo/*', '/foo/bar', true],
+    ['/foo/*', '/foo/', false],
+    ['/foo/*', '/foo/bar/baz', false],
+    ['/foo/*', '/foo', false],
+
+    // * as partial segment
+    ['/foo-*/bar', '/foo-123/bar', true],
+    ['/foo-*/bar', '/foo-/bar', false],
+    ['/foo-*/bar', '/foo/bar', false],
+    ['/foo-*/bar', '/fooX/bar', false],
+    ['/*-bar', '/foo-bar', true],
+    ['/*-bar', '/foo-baz', false],
+    ['/foo-*-baz', '/foo-bar-baz', true],
+    ['/foo-*-baz', '/foo-bar', false],
+
+    // ** zero segments
+    ['/**/foo', '/foo', true],
+    ['/foo/**', '/foo', true],
+    ['/foo/**/bar', '/foo/bar', true],
+
+    // ** one or more segments
+    ['/foo/**', '/foo/bar', true],
+    ['/foo/**', '/foo/bar/baz', true],
+    ['/foo/**', '/foo/bar/baz/bee', true],
+    ['/**/foo', '/bar/foo', true],
+    ['/**/foo', '/bar/baz/foo', true],
+    ['/**/foo', '/bar', false],
+
+    // ** in middle
+    ['/foo/**/bar', '/foo/x/bar', true],
+    ['/foo/**/bar', '/foo/x/y/z/bar', true],
+    ['/foo/**/bar', '/foo/x/baz', false],
+
+    // * and ** combined
+    ['/foo/*/**', '/foo/bar/baz', true],
+    ['/foo/*/**', '/foo/bar', true], // ** = zero
+    ['/foo/*/**', '/foo', false], // * requires something
+    ['/**/*', '/foo/bar', true],
+    ['/**/*', '/foo/bar/baz', true],
+    ['/**/*', '/foo', true],
+
+    // root and minimal paths
+    ['/', '/', true],
+    ['/', '/foo', false],
+    ['/**', '/', true],
+    ['/**', '/foo', true],
+    ['/**', '/foo/bar', true],
+    ['/*', '/', false],
+    ['/**', '', false],
+
+    // trailing and double slash handling
+    ['/foo/bar', '/foo/bar/', true],
+    ['/foo/bar/', '/foo/bar', true],
+    ['/foo/*', '/foo/bar/', true],
+    ['/foo/**/bar', '/foo//bar', true],
+] as const
+
+test('URL pattern matcher', t => {
+    for (const [p, u, exp] of cases) {
+        const comp = compilePattern(p)
+        const res = matchPattern(comp, u)
+        t.assert.equal(res, exp, `Match failed: ${p} on ${u}`)
+    }
+})
 
 test('URL matcher', t => {
     const matcher = URLMatcher([['/'], ['/path', ['/path', '/ruta']], ['/*rest', ['/*rest', '/*rest']]], ['en', 'es'])

--- a/packages/wuchale/src/url.test.ts
+++ b/packages/wuchale/src/url.test.ts
@@ -1,77 +1,78 @@
 // $ node --import ../testing/resolve.ts %f
 
-import { test } from 'node:test'
-import { compilePattern, matchPattern, URLMatcher } from './url.js'
+import { type TestContext, test } from 'node:test'
+import { compilePattern, matchPattern, stringifyPattern, URLMatcher } from './url.js'
 
 const cases = [
-    // Exact (no wildcards)
-    ['/foo/bar', '/foo/bar', true],
+    // Exact
+    ['/foo/bar', '/foo/bar', []],
     ['/foo/bar', '/foo/baz', false],
     ['/foo/bar', '/foo/bar/baz', false],
 
     // * within segment
-    ['/foo/*', '/foo/bar', true],
+    ['/foo/*', '/foo/bar', ['bar']],
     ['/foo/*', '/foo/', false],
     ['/foo/*', '/foo/bar/baz', false],
     ['/foo/*', '/foo', false],
 
     // * as partial segment
-    ['/foo-*/bar', '/foo-123/bar', true],
+    ['/foo-*/bar', '/foo-123/bar', ['123']],
     ['/foo-*/bar', '/foo-/bar', false],
-    ['/foo-*/bar', '/foo/bar', false],
     ['/foo-*/bar', '/fooX/bar', false],
-    ['/*-bar', '/foo-bar', true],
-    ['/*-bar', '/foo-baz', false],
-    ['/foo-*-baz', '/foo-bar-baz', true],
-    ['/foo-*-baz', '/foo-bar', false],
+    ['/foo-*-baz', '/foo-bar-baz', ['bar']],
 
-    // ** zero segments
-    ['/**/foo', '/foo', true],
-    ['/foo/**', '/foo', true],
-    ['/foo/**/bar', '/foo/bar', true],
-
-    // ** one or more segments
-    ['/foo/**', '/foo/bar', true],
-    ['/foo/**', '/foo/bar/baz', true],
-    ['/foo/**', '/foo/bar/baz/bee', true],
-    ['/**/foo', '/bar/foo', true],
-    ['/**/foo', '/bar/baz/foo', true],
+    // ** positions
+    ['/**/foo', '/foo', ['']],
+    ['/**/foo', '/bar/baz/foo', ['/bar/baz']],
     ['/**/foo', '/bar', false],
-
-    // ** in middle
-    ['/foo/**/bar', '/foo/x/bar', true],
-    ['/foo/**/bar', '/foo/x/y/z/bar', true],
+    ['/foo/**', '/foo', ['']],
+    ['/foo/**/bar', '/foo/x/y/z/bar', ['/x/y/z']],
     ['/foo/**/bar', '/foo/x/baz', false],
 
     // * and ** combined
-    ['/foo/*/**', '/foo/bar/baz', true],
-    ['/foo/*/**', '/foo/bar', true], // ** = zero
-    ['/foo/*/**', '/foo', false], // * requires something
-    ['/**/*', '/foo/bar', true],
-    ['/**/*', '/foo/bar/baz', true],
-    ['/**/*', '/foo', true],
+    ['/foo/*/**', '/foo/bar', ['bar']],
+    ['/foo/*/**', '/foo', false],
+    ['/**/*', '/foo', ['/foo']],
+    ['/**/*', '/', false],
 
-    // root and minimal paths
-    ['/', '/', true],
+    // root
+    ['/', '/', []],
     ['/', '/foo', false],
-    ['/**', '/', true],
-    ['/**', '/foo', true],
-    ['/**', '/foo/bar', true],
-    ['/*', '/', false],
+    ['/**', '/', ['/']],
     ['/**', '', false],
+    ['/*', '/', false],
 
-    // trailing and double slash handling
-    ['/foo/bar', '/foo/bar/', true],
-    ['/foo/bar/', '/foo/bar', true],
-    ['/foo/*', '/foo/bar/', true],
-    ['/foo/**/bar', '/foo//bar', true],
+    // trailing/double slash
+    ['/foo/bar', '/foo/bar/', []],
+    ['/foo/**/bar', '/foo//bar', ['/']],
+
+    // complex groups
+    ['/foo/*/**/*/bar', '/foo/a/b/bar', ['a/b']],
+    ['/foo/*/**/*/bar', '/foo/a/x/y/b/bar', ['a/x/y/b']],
+    ['/foo/*/**/*/bar', '/foo/a/bar', false],
+    ['/foo/*/**/*/*/bar/*', '/foo/a/x/y/z/b/c/bar/d', ['a/x/y/z/b/c', 'd']],
+    ['/foo/*/**/*/*/bar/*', '/foo/a/b/bar/d', false],
 ] as const
 
-test('URL pattern matcher', t => {
+test('URL pattern matcher', (t: TestContext) => {
     for (const [p, u, exp] of cases) {
-        const comp = compilePattern(p)
-        const res = matchPattern(comp, u)
-        t.assert.equal(res, exp, `Match failed: ${p} on ${u}`)
+        const compiled = compilePattern(p)
+        const res = matchPattern(compiled, u)
+        t.assert.deepStrictEqual(res, exp, `Match failed: ${p} on ${u}`)
+    }
+})
+
+test('URL pattern compile and stringify', (t: TestContext) => {
+    for (const [p, u, dyn] of cases) {
+        if (dyn === false) {
+            continue
+        }
+        const compiled = compilePattern(p)
+        let str = stringifyPattern(compiled, dyn)
+        if (str.length > 1 && u.endsWith('/')) {
+            str += '/'
+        }
+        t.assert.equal(str, u, `Compile stringify failed: ${p} on ${u} with ${JSON.stringify(dyn)}`)
     }
 })
 

--- a/packages/wuchale/src/url.test.ts
+++ b/packages/wuchale/src/url.test.ts
@@ -10,7 +10,7 @@ const cases = [
     ['/foo/bar', '/foo/bar/baz', false],
 
     // * within segment
-    ['/foo/*', '/foo/bar', ['bar']],
+    ['/foo/*', '/foo/bar', ['/bar']],
     ['/foo/*', '/foo/', false],
     ['/foo/*', '/foo/bar/baz', false],
     ['/foo/*', '/foo', false],
@@ -20,6 +20,26 @@ const cases = [
     ['/foo-*/bar', '/foo-/bar', false],
     ['/foo-*/bar', '/fooX/bar', false],
     ['/foo-*-baz', '/foo-bar-baz', ['bar']],
+    ['/foo-?-baz', '/foo-bar-baz', ['bar']],
+    ['/foo-?-baz', '/foo--baz', ['']],
+
+    // basic optional segment
+    ['/foo/?/bar', '/foo/bar', ['']],
+    ['/foo/?/bar', '/foo/baz/bar', ['/baz']],
+    ['/foo/?/bar', '/foo/bar/baz', false],
+
+    // optional at start
+    ['/?/foo', '/foo', ['']],
+    ['/?/foo', '/bar/foo', ['/bar']],
+    ['/?/foo', '/bar/baz/foo', false],
+
+    // optional at end
+    ['/foo/?', '/foo', []],
+    ['/foo/?', '/foo/bar', ['/bar']],
+
+    // optional with other wildcards
+    ['/foo/?/**/bar', '/foo/bar', ['']],
+    ['/foo/?/**/bar', '/foo/baz/x/y/bar', ['/baz/x/y']],
 
     // ** positions
     ['/**/foo', '/foo', ['']],
@@ -30,7 +50,7 @@ const cases = [
     ['/foo/**/bar', '/foo/x/baz', false],
 
     // * and ** combined
-    ['/foo/*/**', '/foo/bar', ['bar']],
+    ['/foo/*/**', '/foo/bar', ['/bar']],
     ['/foo/*/**', '/foo', false],
     ['/**/*', '/foo', ['/foo']],
     ['/**/*', '/', false],
@@ -47,10 +67,10 @@ const cases = [
     ['/foo/**/bar', '/foo//bar', ['/']],
 
     // complex groups
-    ['/foo/*/**/*/bar', '/foo/a/b/bar', ['a/b']],
-    ['/foo/*/**/*/bar', '/foo/a/x/y/b/bar', ['a/x/y/b']],
+    ['/foo/*/**/*/bar', '/foo/a/b/bar', ['/a/b']],
+    ['/foo/*/**/*/bar', '/foo/a/x/y/b/bar', ['/a/x/y/b']],
     ['/foo/*/**/*/bar', '/foo/a/bar', false],
-    ['/foo/*/**/*/*/bar/*', '/foo/a/x/y/z/b/c/bar/d', ['a/x/y/z/b/c', 'd']],
+    ['/foo/*/**/*/*/bar/*', '/foo/a/x/y/z/b/c/bar/d', ['/a/x/y/z/b/c', '/d']],
     ['/foo/*/**/*/*/bar/*', '/foo/a/b/bar/d', false],
 ] as const
 

--- a/packages/wuchale/src/url.test.ts
+++ b/packages/wuchale/src/url.test.ts
@@ -77,20 +77,33 @@ test('URL pattern compile and stringify', (t: TestContext) => {
 })
 
 test('URL matcher', t => {
-    const matcher = URLMatcher([['/'], ['/path', ['/path', '/ruta']], ['/*rest', ['/*rest', '/*rest']]], ['en', 'es'])
+    const matcher = URLMatcher(
+        [
+            [['/']],
+            [['/path'], [['/path'], ['/ruta']]],
+            [
+                ['/', 1],
+                [
+                    ['/', 1],
+                    ['/', 1],
+                ],
+            ],
+        ],
+        ['en', 'es'],
+    )
     t.assert.deepEqual(matcher('/', 'en'), {
         path: '/',
-        altPatterns: { en: '/', es: '/' },
-        params: {},
+        altPatterns: { en: ['/'], es: ['/'] },
+        params: [],
     })
     t.assert.deepEqual(matcher('/foo', 'es'), {
         path: '/foo',
-        altPatterns: { en: '/*rest', es: '/*rest' },
-        params: { rest: 'foo' },
+        altPatterns: { en: ['/', 1], es: ['/', 1] },
+        params: ['foo'],
     })
     t.assert.deepEqual(matcher('/ruta', 'es'), {
         path: '/path',
-        altPatterns: { en: '/path', es: '/ruta' },
-        params: {},
+        altPatterns: { en: ['/path'], es: ['/ruta'] },
+        params: [],
     })
 })

--- a/packages/wuchale/src/url.ts
+++ b/packages/wuchale/src/url.ts
@@ -1,3 +1,5 @@
+// $ node --import ../testing/resolve.ts %n.test.ts
+
 import { compile, match } from 'path-to-regexp'
 
 export type URLLocalizer = (url: string, locale: string) => string
@@ -76,9 +78,10 @@ export function URLMatcher<L extends string>(manifest: URLManifest, locales: L[]
     }
 }
 
-const wilds = ['/*/**', '/**/*', '/**', '*'] as const
+const wilds = ['/**', '*'] as const // longer should be first
 
-const DOUBLE = 2 // index of /**
+const DOUBLE = 0 // index of **
+const SINGLE = 1 // index of *
 
 export type Pattern = (string | number)[]
 
@@ -87,6 +90,7 @@ export function compilePattern(pattern: string) {
     if (pattern.length > 1 && pattern.endsWith('/')) {
         pattern = pattern.slice(0, -1)
     }
+    let prevWildI = [-1, -1] as [number, number] // corresponsing to wilds
     for (let i = 0; i < pattern.length; i++) {
         let iWildInPatMin = -1
         let wildIdxMin: number | null = null
@@ -100,57 +104,122 @@ export function compilePattern(pattern: string) {
         }
         if (wildIdxMin === null) {
             parts.push(pattern.slice(i))
+            prevWildI = [-1, -1]
             break
         }
-        const wild = wilds[wildIdxMin]!
-        if (iWildInPatMin > 0) {
-            parts.push(pattern.slice(i, iWildInPatMin))
+        if (iWildInPatMin > 0 && iWildInPatMin > i) {
+            const slice = pattern.slice(i, iWildInPatMin)
+            if (slice !== '/' || i === 0) {
+                parts.push(slice)
+                prevWildI = [-1, -1]
+            }
         }
-        parts.push(wildIdxMin)
-        i = iWildInPatMin + wild.length - 1
+        if (wildIdxMin === DOUBLE) {
+            if (prevWildI[DOUBLE] === -1) {
+                prevWildI[DOUBLE] = parts.length
+                parts.push(wildIdxMin)
+            }
+        } else if (wildIdxMin === SINGLE) {
+            if (prevWildI[SINGLE] === -1) {
+                prevWildI[SINGLE] = parts.length
+                parts.push(1)
+            } else {
+                ;(parts[prevWildI[SINGLE]] as number)++
+            }
+        }
+        i = iWildInPatMin + wilds[wildIdxMin]!.length - 1
     }
     return parts
 }
 
+function countSlash(url: string, fromIdx: number, toIdx?: number) {
+    let count = 0
+    for (let i = url.indexOf('/', fromIdx); i !== -1 && i < (toIdx ?? url.length); i = url.indexOf('/', i + 1)) {
+        count++
+    }
+    return count
+}
+
+const slashCheckFails = (slashes: number, singles: number, double: boolean) =>
+    slashes < singles - 1 || (!double && slashes >= singles)
+
 export function matchPattern(pattern: Pattern, url: string) {
-    let lastWild: number | null = null
-    let lastI = 0
     if (url.length > 1 && url.endsWith('/')) {
         url = url.slice(0, -1)
     }
+    let hasDoubleLast = false
+    let singlesLast = 0
+    let lastI = 0
+    const dynamics: string[] = []
     for (const patt of pattern) {
         if (typeof patt === 'number') {
-            lastWild = patt
+            if (patt === 0) {
+                hasDoubleLast = true
+            } else {
+                singlesLast = patt
+            }
             continue
         }
-        const wild = lastWild
-        lastWild = null // reset
+        const singles = singlesLast
+        const hasDouble = hasDoubleLast
+        singlesLast = 0
+        hasDoubleLast = false
         const i = url.indexOf(patt, lastI)
+        const prevI = lastI
+        lastI = i + patt.length
         if (i === -1) {
             return false
         }
-        if (wild === null) {
+        if (singles === 0 && !hasDouble) {
             if (i > 0) {
                 return false
             }
-            lastI = i + patt.length
             continue
         }
-        if (wild <= DOUBLE) {
-            lastI = i + patt.length
-            continue
-        }
-        const iSlash = url.indexOf('/', lastI)
-        if ((iSlash > lastI && iSlash < i) || iSlash === lastI) {
+        if (singles > 0 && (i === prevI || slashCheckFails(countSlash(url, prevI, i), singles, hasDouble))) {
             return false
         }
-        lastI = i + patt.length
+        dynamics.push(url.slice(prevI, i))
     }
     if (lastI === url.length) {
-        return (lastWild === null || lastWild === DOUBLE) && lastI > 0
+        if (singlesLast > 0 || lastI === 0) {
+            return false
+        }
+        if (!hasDoubleLast) {
+            return dynamics
+        }
     }
-    if (lastWild === null) {
+    if (singlesLast > 0) {
+        const slashCount = countSlash(url, lastI)
+        if (slashCheckFails(slashCount, singlesLast, hasDoubleLast) || url.length === slashCount) {
+            return false
+        }
+    } else if (!hasDoubleLast) {
         return false
     }
-    return lastWild <= DOUBLE || url.indexOf('/', lastI) === -1
+    if (!hasDoubleLast && url.indexOf('/', lastI) !== -1) {
+        return false
+    }
+    dynamics.push(url.slice(lastI))
+    return dynamics
+}
+
+export function stringifyPattern(pattern: Pattern, dynamics: readonly string[]) {
+    let i = 0
+    let lastIsDynamic = false
+    const assembled: string[] = []
+    for (const p of pattern) {
+        if (typeof p === 'string') {
+            assembled.push(p)
+            lastIsDynamic = false
+            continue
+        }
+        if (lastIsDynamic) {
+            continue
+        }
+        assembled.push(dynamics[i]!)
+        i++
+        lastIsDynamic = true
+    }
+    return assembled.join('')
 }

--- a/packages/wuchale/src/url.ts
+++ b/packages/wuchale/src/url.ts
@@ -75,3 +75,82 @@ export function URLMatcher<L extends string>(manifest: URLManifest, locales: L[]
         return noMatchRes
     }
 }
+
+const wilds = ['/*/**', '/**/*', '/**', '*'] as const
+
+const DOUBLE = 2 // index of /**
+
+export type Pattern = (string | number)[]
+
+export function compilePattern(pattern: string) {
+    const parts: Pattern = []
+    if (pattern.length > 1 && pattern.endsWith('/')) {
+        pattern = pattern.slice(0, -1)
+    }
+    for (let i = 0; i < pattern.length; i++) {
+        let iWildInPatMin = -1
+        let wildIdxMin: number | null = null
+        for (const [wi, wild] of wilds.entries()) {
+            const iWildInPat = pattern.indexOf(wild, i)
+            if (iWildInPat === -1 || (iWildInPatMin !== -1 && iWildInPat >= iWildInPatMin)) {
+                continue
+            }
+            iWildInPatMin = iWildInPat
+            wildIdxMin = wi
+        }
+        if (wildIdxMin === null) {
+            parts.push(pattern.slice(i))
+            break
+        }
+        const wild = wilds[wildIdxMin]!
+        if (iWildInPatMin > 0) {
+            parts.push(pattern.slice(i, iWildInPatMin))
+        }
+        parts.push(wildIdxMin)
+        i = iWildInPatMin + wild.length - 1
+    }
+    return parts
+}
+
+export function matchPattern(pattern: Pattern, url: string) {
+    let lastWild: number | null = null
+    let lastI = 0
+    if (url.length > 1 && url.endsWith('/')) {
+        url = url.slice(0, -1)
+    }
+    for (const patt of pattern) {
+        if (typeof patt === 'number') {
+            lastWild = patt
+            continue
+        }
+        const wild = lastWild
+        lastWild = null // reset
+        const i = url.indexOf(patt, lastI)
+        if (i === -1) {
+            return false
+        }
+        if (wild === null) {
+            if (i > 0) {
+                return false
+            }
+            lastI = i + patt.length
+            continue
+        }
+        if (wild <= DOUBLE) {
+            lastI = i + patt.length
+            continue
+        }
+        const iSlash = url.indexOf('/', lastI)
+        if ((iSlash > lastI && iSlash < i) || iSlash === lastI) {
+            return false
+        }
+        lastI = i + patt.length
+    }
+    if (lastI === url.length) {
+        return (lastWild === null || lastWild === DOUBLE) && lastI > 0
+    }
+    if (lastWild === null) {
+        return false
+    }
+    return lastWild <= DOUBLE || url.indexOf('/', lastI) === -1
+}

--- a/packages/wuchale/src/url.ts
+++ b/packages/wuchale/src/url.ts
@@ -1,4 +1,3 @@
-// $ node %f
 // $ node --import ../testing/resolve.ts %n.test.ts
 
 const wilds = ['/**', '/*', '*', '/?', '?'] as const // longer should be first
@@ -6,7 +5,7 @@ const wilds = ['/**', '/*', '*', '/?', '?'] as const // longer should be first
 const [DOUBLE, SINGLESL, SINGLE, OPTIONALSL, OPTIONAL] = [0, 1, 2, 3, 4] as const
 // meanings
 const [HASDOUBLE, HASSINGLE, SINGLESMIN, OPTIONALMAX, HASOPTIONAL] = [0, 1, 2, -2, -1] as const
-const DEFAULT_PREV_WILD = [false, false, -1, -1, false] as [boolean, boolean, number, number, boolean]
+const DEFAULT_PREV_WILD = [false, -1, false, -1, false] as [boolean, number, boolean, number, boolean]
 
 export type Pattern = (string | number)[]
 
@@ -15,12 +14,12 @@ export function compilePattern(pattern: string) {
     if (pattern.length > 1 && pattern.endsWith('/')) {
         pattern = pattern.slice(0, -1)
     }
-    let [prevHasDouble, prevHasSingle, prevOptionalsI, prevSinglesI, prevHasOptional] = DEFAULT_PREV_WILD
+    let prevProps = DEFAULT_PREV_WILD.slice() as typeof DEFAULT_PREV_WILD
     for (let i = 0; i < pattern.length; i++) {
         let iWildInPatMin = -1
         let wildIdxMin: number | null = null
-        for (const [wi, wild] of wilds.entries()) {
-            const iWildInPat = pattern.indexOf(wild, i)
+        for (let wi = 0; wi < wilds.length; wi++) {
+            const iWildInPat = pattern.indexOf(wilds[wi]!, i)
             if (iWildInPat === -1 || (iWildInPatMin !== -1 && iWildInPat >= iWildInPatMin)) {
                 continue
             }
@@ -29,44 +28,44 @@ export function compilePattern(pattern: string) {
         }
         if (wildIdxMin === null) {
             parts.push(pattern.slice(i))
-            ;[prevHasDouble, prevHasSingle, prevOptionalsI, prevSinglesI, prevHasOptional] = DEFAULT_PREV_WILD
+            prevProps = DEFAULT_PREV_WILD.slice() as typeof DEFAULT_PREV_WILD
             break
         }
-        if (iWildInPatMin > 0 && iWildInPatMin > i) {
+        if (iWildInPatMin > i) {
             const slice = pattern.slice(i, iWildInPatMin)
             if (slice !== '/' || i === 0) {
                 parts.push(slice)
-                ;[prevHasDouble, prevHasSingle, prevOptionalsI, prevSinglesI, prevHasOptional] = DEFAULT_PREV_WILD
+                prevProps = DEFAULT_PREV_WILD.slice() as typeof DEFAULT_PREV_WILD
             }
         }
         if (wildIdxMin === DOUBLE) {
-            if (!prevHasDouble) {
-                prevHasDouble = true
+            if (!prevProps[DOUBLE]) {
+                prevProps[DOUBLE] = true
                 parts.push(HASDOUBLE)
             }
         } else if (wildIdxMin === OPTIONAL) {
-            if (!prevHasOptional) {
-                prevHasOptional = true
+            if (!prevProps[OPTIONAL]) {
+                prevProps[OPTIONAL] = true
                 parts.push(HASOPTIONAL)
             }
         } else if (wildIdxMin === OPTIONALSL) {
-            if (prevOptionalsI === -1) {
-                prevOptionalsI = parts.length
+            if (prevProps[OPTIONALSL] === -1) {
+                prevProps[OPTIONALSL] = parts.length
                 parts.push(OPTIONALMAX)
             } else {
-                ;(parts[prevOptionalsI] as number)--
+                ;(parts[prevProps[OPTIONALSL]] as number)--
             }
         } else if (wildIdxMin === SINGLE) {
-            if (!prevHasSingle) {
-                prevHasSingle = true
+            if (!prevProps[SINGLE]) {
+                prevProps[SINGLE] = true
                 parts.push(HASSINGLE)
             }
         } else if (wildIdxMin === SINGLESL) {
-            if (prevSinglesI === -1) {
-                prevSinglesI = parts.length
+            if (prevProps[SINGLESL] === -1) {
+                prevProps[SINGLESL] = parts.length
                 parts.push(SINGLESMIN)
             } else {
-                ;(parts[prevSinglesI] as number)++
+                ;(parts[prevProps[SINGLESL]] as number)++
             }
         }
         i = iWildInPatMin + wilds[wildIdxMin]!.length - 1
@@ -93,15 +92,16 @@ function slashCheckFails(
     for (let i = url.indexOf('/', fromI); i !== -1 && i < toI; i = url.indexOf('/', i + 1)) {
         slashes++
     }
-    if (url.length === slashes) {
+    if (toI - fromI === slashes) {
         return true
     }
     return slashes < singles || (!double && slashes - optionals > singles)
 }
 
 export function matchPattern(pattern: Pattern, url: string) {
-    if (url.length > 1 && url.endsWith('/')) {
-        url = url.slice(0, -1)
+    let endI = url.length
+    if (endI > 1 && url.endsWith('/')) {
+        endI--
     }
     let hasDoubleLast = false
     let singlesLast = 0
@@ -141,7 +141,7 @@ export function matchPattern(pattern: Pattern, url: string) {
         if (i === -1) {
             return false
         }
-        if (singles === 0 && !hasDouble && optionals === 0 && !hasOptional && !hasSingle) {
+        if (!hasDouble && !hasOptional && !hasSingle && singles === 0 && optionals === 0) {
             if (i > 0) {
                 return false
             }
@@ -152,7 +152,7 @@ export function matchPattern(pattern: Pattern, url: string) {
         }
         dynamics.push(url.slice(prevI, i))
     }
-    if (lastI === url.length) {
+    if (lastI === endI) {
         if (singlesLast > 0 || lastI === 0) {
             return false
         }
@@ -163,31 +163,30 @@ export function matchPattern(pattern: Pattern, url: string) {
     if (!hasDoubleLast && !hasOptionalLast && !hasSingleLast && singlesLast === 0 && optionalsLast === 0) {
         return false
     }
-    if (slashCheckFails(url, lastI, url.length, singlesLast, optionalsLast, hasDoubleLast, hasSingleLast)) {
+    if (slashCheckFails(url, lastI, endI, singlesLast, optionalsLast, hasDoubleLast, hasSingleLast)) {
         return false
     }
-    dynamics.push(url.slice(lastI))
+    dynamics.push(url.slice(lastI, endI))
     return dynamics
 }
 
 export function stringifyPattern(pattern: Pattern, dynamics: readonly string[]) {
     let i = 0
     let lastIsDynamic = false
-    const assembled: string[] = []
+    let assembled = ''
     for (const p of pattern) {
         if (typeof p === 'string') {
-            assembled.push(p)
+            assembled += p
             lastIsDynamic = false
             continue
         }
         if (lastIsDynamic) {
             continue
         }
-        assembled.push(dynamics[i]!)
-        i++
+        assembled += dynamics[i++] ?? '' // undefined when optional and []
         lastIsDynamic = true
     }
-    return assembled.join('')
+    return assembled
 }
 
 export type URLManifestItem =

--- a/packages/wuchale/src/url.ts
+++ b/packages/wuchale/src/url.ts
@@ -1,83 +1,5 @@
 // $ node --import ../testing/resolve.ts %n.test.ts
 
-import { compile, match } from 'path-to-regexp'
-
-export type URLLocalizer = (url: string, locale: string) => string
-
-// public default, used when localized: true
-export const localizeDefault: URLLocalizer = (path, loc) => {
-    const localized = `/${loc}${path}`
-    if (!localized.endsWith('/')) {
-        return localized
-    }
-    return localized.slice(0, -1)
-}
-
-export const deLocalizeDefault = <L extends string>(path: string, locales: L[]): [string, L | null] => {
-    let iSecondSlash = path.indexOf('/', 2)
-    if (iSecondSlash === -1) {
-        iSecondSlash = path.length
-    }
-    const locale = path.slice(1, iSecondSlash) as L
-    if (!locales.includes(locale)) {
-        return [path, null]
-    }
-    const rest = path.slice(1 + locale.length)
-    return [rest || '/', locale]
-}
-
-type MatchParams = Partial<Record<string, string | string[]>>
-
-const getParams = (path: string, pattern: string): MatchParams | undefined => {
-    const matched = match(pattern, { decode: false })(path)
-    if (!matched) {
-        return
-    }
-    return matched.params
-}
-
-export const fillParams = (params: MatchParams, destPattern: string) => {
-    const compiled = compile(destPattern, { encode: false })
-    return compiled(params)
-}
-
-export type URLManifestItem =
-    | [
-          string, // /path
-          string[], // /path, /ruta
-      ]
-    | [string] // just /path
-
-export type URLManifest = URLManifestItem[]
-
-type MatchResult<L extends string> = {
-    path: string | null
-    params: MatchParams
-    altPatterns: Record<L, string>
-}
-
-const noMatchRes: MatchResult<string> = { path: null, altPatterns: {}, params: {} }
-
-export function URLMatcher<L extends string>(manifest: URLManifest, locales: L[]) {
-    const manifestWithLocales = manifest.map(([pattern, localized]) => {
-        localized ??= locales.map(_ => pattern)
-        const locAndLocalizeds = locales.map((loc, i) => [loc, localized[i]] as [string, string])
-        return [pattern, Object.fromEntries(locAndLocalizeds)] as [string, Record<string, string>]
-    })
-    return (url: string, locale: L | null): MatchResult<L> => {
-        if (locale === null) {
-            return noMatchRes
-        }
-        for (const [pattern, altPatterns] of manifestWithLocales) {
-            const params = getParams(url, altPatterns[locale]!)
-            if (params) {
-                return { path: fillParams(params, pattern), params, altPatterns }
-            }
-        }
-        return noMatchRes
-    }
-}
-
 const wilds = ['/**', '*'] as const // longer should be first
 
 const DOUBLE = 0 // index of **
@@ -222,4 +144,65 @@ export function stringifyPattern(pattern: Pattern, dynamics: readonly string[]) 
         lastIsDynamic = true
     }
     return assembled.join('')
+}
+
+export type URLManifestItem =
+    | [
+          Pattern, // ['/path'] base pattern
+          Pattern[], // [['/path'], ['/ruta']] for en, es
+      ]
+    | [Pattern] // just ['/path'] for all
+
+export type URLManifest = URLManifestItem[]
+
+type MatchResult<L extends string> = {
+    path: string | null
+    params: string[]
+    altPatterns: Record<L, Pattern>
+}
+
+const noMatchRes: MatchResult<string> = { path: null, altPatterns: {}, params: [] }
+
+export function URLMatcher<L extends string>(manifest: URLManifest, locales: L[]) {
+    const manifestWithLocales = manifest.map(([pattern, localized]) => {
+        localized ??= locales.map(_ => pattern)
+        const locAndLocalizeds = locales.map((loc, i) => [loc, localized[i]] as [string, Pattern])
+        return [pattern, Object.fromEntries(locAndLocalizeds)] as [Pattern, Record<L, Pattern>]
+    })
+    return (url: string, locale: L | null): MatchResult<L> => {
+        if (locale === null) {
+            return noMatchRes
+        }
+        for (const [pattern, altPatterns] of manifestWithLocales) {
+            const params = matchPattern(altPatterns[locale]!, url)
+            if (params) {
+                return { path: stringifyPattern(pattern, params), params, altPatterns }
+            }
+        }
+        return noMatchRes
+    }
+}
+
+export type URLLocalizer = (url: string, locale: string) => string
+
+// public default, used when localized: true
+export const localizeDefault: URLLocalizer = (path, loc) => {
+    const localized = `/${loc}${path}`
+    if (!localized.endsWith('/')) {
+        return localized
+    }
+    return localized.slice(0, -1)
+}
+
+export const deLocalizeDefault = <L extends string>(path: string, locales: L[]): [string, L | null] => {
+    let iSecondSlash = path.indexOf('/', 2)
+    if (iSecondSlash === -1) {
+        iSecondSlash = path.length
+    }
+    const locale = path.slice(1, iSecondSlash) as L
+    if (!locales.includes(locale)) {
+        return [path, null]
+    }
+    const rest = path.slice(1 + locale.length)
+    return [rest || '/', locale]
 }

--- a/packages/wuchale/src/url.ts
+++ b/packages/wuchale/src/url.ts
@@ -1,9 +1,12 @@
+// $ node %f
 // $ node --import ../testing/resolve.ts %n.test.ts
 
-const wilds = ['/**', '*'] as const // longer should be first
-
-const DOUBLE = 0 // index of **
-const SINGLE = 1 // index of *
+const wilds = ['/**', '/*', '*', '/?', '?'] as const // longer should be first
+// corresponsing indices
+const [DOUBLE, SINGLESL, SINGLE, OPTIONALSL, OPTIONAL] = [0, 1, 2, 3, 4] as const
+// meanings
+const [HASDOUBLE, HASSINGLE, SINGLESMIN, OPTIONALMAX, HASOPTIONAL] = [0, 1, 2, -2, -1] as const
+const DEFAULT_PREV_WILD = [false, false, -1, -1, false] as [boolean, boolean, number, number, boolean]
 
 export type Pattern = (string | number)[]
 
@@ -12,7 +15,7 @@ export function compilePattern(pattern: string) {
     if (pattern.length > 1 && pattern.endsWith('/')) {
         pattern = pattern.slice(0, -1)
     }
-    let prevWildI = [-1, -1] as [number, number] // corresponsing to wilds
+    let [prevHasDouble, prevHasSingle, prevOptionalsI, prevSinglesI, prevHasOptional] = DEFAULT_PREV_WILD
     for (let i = 0; i < pattern.length; i++) {
         let iWildInPatMin = -1
         let wildIdxMin: number | null = null
@@ -26,27 +29,44 @@ export function compilePattern(pattern: string) {
         }
         if (wildIdxMin === null) {
             parts.push(pattern.slice(i))
-            prevWildI = [-1, -1]
+            ;[prevHasDouble, prevHasSingle, prevOptionalsI, prevSinglesI, prevHasOptional] = DEFAULT_PREV_WILD
             break
         }
         if (iWildInPatMin > 0 && iWildInPatMin > i) {
             const slice = pattern.slice(i, iWildInPatMin)
             if (slice !== '/' || i === 0) {
                 parts.push(slice)
-                prevWildI = [-1, -1]
+                ;[prevHasDouble, prevHasSingle, prevOptionalsI, prevSinglesI, prevHasOptional] = DEFAULT_PREV_WILD
             }
         }
         if (wildIdxMin === DOUBLE) {
-            if (prevWildI[DOUBLE] === -1) {
-                prevWildI[DOUBLE] = parts.length
-                parts.push(wildIdxMin)
+            if (!prevHasDouble) {
+                prevHasDouble = true
+                parts.push(HASDOUBLE)
+            }
+        } else if (wildIdxMin === OPTIONAL) {
+            if (!prevHasOptional) {
+                prevHasOptional = true
+                parts.push(HASOPTIONAL)
+            }
+        } else if (wildIdxMin === OPTIONALSL) {
+            if (prevOptionalsI === -1) {
+                prevOptionalsI = parts.length
+                parts.push(OPTIONALMAX)
+            } else {
+                ;(parts[prevOptionalsI] as number)--
             }
         } else if (wildIdxMin === SINGLE) {
-            if (prevWildI[SINGLE] === -1) {
-                prevWildI[SINGLE] = parts.length
-                parts.push(1)
+            if (!prevHasSingle) {
+                prevHasSingle = true
+                parts.push(HASSINGLE)
+            }
+        } else if (wildIdxMin === SINGLESL) {
+            if (prevSinglesI === -1) {
+                prevSinglesI = parts.length
+                parts.push(SINGLESMIN)
             } else {
-                ;(parts[prevWildI[SINGLE]] as number)++
+                ;(parts[prevSinglesI] as number)++
             }
         }
         i = iWildInPatMin + wilds[wildIdxMin]!.length - 1
@@ -54,16 +74,30 @@ export function compilePattern(pattern: string) {
     return parts
 }
 
-function countSlash(url: string, fromIdx: number, toIdx?: number) {
-    let count = 0
-    for (let i = url.indexOf('/', fromIdx); i !== -1 && i < (toIdx ?? url.length); i = url.indexOf('/', i + 1)) {
-        count++
+function slashCheckFails(
+    url: string,
+    fromI: number,
+    toI: number,
+    singles: number,
+    optionals: number,
+    double: boolean,
+    single: boolean,
+) {
+    if (fromI === toI) {
+        return singles > 0 || single
     }
-    return count
+    if (singles === 0 && optionals === 0) {
+        return false
+    }
+    let slashes = 0
+    for (let i = url.indexOf('/', fromI); i !== -1 && i < toI; i = url.indexOf('/', i + 1)) {
+        slashes++
+    }
+    if (url.length === slashes) {
+        return true
+    }
+    return slashes < singles || (!double && slashes - optionals > singles)
 }
-
-const slashCheckFails = (slashes: number, singles: number, double: boolean) =>
-    slashes < singles - 1 || (!double && slashes >= singles)
 
 export function matchPattern(pattern: Pattern, url: string) {
     if (url.length > 1 && url.endsWith('/')) {
@@ -71,34 +105,49 @@ export function matchPattern(pattern: Pattern, url: string) {
     }
     let hasDoubleLast = false
     let singlesLast = 0
+    let optionalsLast = 0
+    let hasSingleLast = false
+    let hasOptionalLast = false
     let lastI = 0
     const dynamics: string[] = []
     for (const patt of pattern) {
         if (typeof patt === 'number') {
-            if (patt === 0) {
+            if (patt === HASDOUBLE) {
                 hasDoubleLast = true
+            } else if (patt <= OPTIONALMAX) {
+                optionalsLast = OPTIONALMAX - patt + 1
+            } else if (patt === HASOPTIONAL) {
+                hasOptionalLast = true
+            } else if (patt === HASSINGLE) {
+                hasSingleLast = true
             } else {
-                singlesLast = patt
+                singlesLast = patt - SINGLESMIN + 1
             }
             continue
         }
         const singles = singlesLast
+        const optionals = optionalsLast
         const hasDouble = hasDoubleLast
+        const hasSingle = hasSingleLast
+        const hasOptional = hasOptionalLast
         singlesLast = 0
+        optionalsLast = 0
         hasDoubleLast = false
+        hasOptionalLast = false
+        hasSingleLast = false
         const i = url.indexOf(patt, lastI)
         const prevI = lastI
         lastI = i + patt.length
         if (i === -1) {
             return false
         }
-        if (singles === 0 && !hasDouble) {
+        if (singles === 0 && !hasDouble && optionals === 0 && !hasOptional && !hasSingle) {
             if (i > 0) {
                 return false
             }
             continue
         }
-        if (singles > 0 && (i === prevI || slashCheckFails(countSlash(url, prevI, i), singles, hasDouble))) {
+        if (slashCheckFails(url, prevI, i, singles, optionals, hasDouble, hasSingle)) {
             return false
         }
         dynamics.push(url.slice(prevI, i))
@@ -111,15 +160,10 @@ export function matchPattern(pattern: Pattern, url: string) {
             return dynamics
         }
     }
-    if (singlesLast > 0) {
-        const slashCount = countSlash(url, lastI)
-        if (slashCheckFails(slashCount, singlesLast, hasDoubleLast) || url.length === slashCount) {
-            return false
-        }
-    } else if (!hasDoubleLast) {
+    if (!hasDoubleLast && !hasOptionalLast && !hasSingleLast && singlesLast === 0 && optionalsLast === 0) {
         return false
     }
-    if (!hasDoubleLast && url.indexOf('/', lastI) !== -1) {
+    if (slashCheckFails(url, lastI, url.length, singlesLast, optionalsLast, hasDoubleLast, hasSingleLast)) {
         return false
     }
     dynamics.push(url.slice(lastI))


### PR DESCRIPTION
Currently we use the `path-to-regex` library because we need two-way conversion to support swapping translatable parts while keeping the dynamic parts the same. However, it introduces  complexity as it is made for another use case where grabbing the dynamic parts is important. When applied to i18n, the param names are easy to mistakenly translate and cause errors, and so wuchale tries to prevent that by replacing them with its own `{0}` syntax. That covers most cases but not all (#328). Considering the fact that the dynamic parts are not relevant to i18n at all, and we only need to keep them the same across translations, the problem becomes much more focused.

This solves it by implementing a custom matcher that accepts glob-like patterns (no named params) and it removes the complexity of having to handle named params. An additional advantage is that it also avoids the use of regular expressions entirely to prevent any vulnerability related to them. It only uses `indexOf` checks, which makes it more performant too. On the configuration side, it will be a bit simpler as its easier to write `/foo/*` than `/foo/:id`.