### PR TITLE
Fix react arrow function components

### DIFF
--- a/packages/jsx/src/transformer.test.ts
+++ b/packages/jsx/src/transformer.test.ts
@@ -55,6 +55,35 @@ test('React basic', async t => {
     )
 })
 
+test('React arrow function component', async t => {
+    transformTest(
+        t,
+        getOutput(tsx`
+        const Foo = () => {
+            return <p>Hello</p>
+        }
+        const m = () => {
+            return <p data-novalue>Hello</p>
+        }
+    `),
+        tsx`
+        import { _w_load_, _w_load_rx_ } from "./loader.js"
+        import W_tx_ from "@wuchale/jsx/runtime.jsx"
+
+        const Foo = () => {
+            const _w_runtime_ = _w_load_rx_();
+            return <p>{_w_runtime_(0)}</p>
+        }
+
+        const m = () => {
+            const _w_runtime_ = _w_load_();
+            return <p data-novalue>{_w_runtime_(0)}</p>
+        }
+    `,
+        ['Hello', 'Hello'],
+    )
+})
+
 test('SolidJS basic', async t => {
     transformTest(
         t,

--- a/packages/wuchale/src/adapter-vanilla/transformer.ts
+++ b/packages/wuchale/src/adapter-vanilla/transformer.ts
@@ -496,6 +496,12 @@ export class Transformer {
                 this.heuristciDetails.topLevelCall = this.getCalleeName(init.callee)
             }
             delete this.heuristciDetails.leftSide
+            if (
+                node.id.type === 'Identifier' &&
+                (init.type === 'ArrowFunctionExpression' || init.type === 'FunctionExpression')
+            ) {
+                return [...msgs, ...this.visitFunctionBody(init.body, node.id.name, init.end)]
+            }
             return [...msgs, ...this.visit(node.init)]
         })
 


### PR DESCRIPTION
When declaring a component like this
```ts
const Foo = () => {
  return <p>Hello</p>
}
```
wuchale does not detect it as a react component. Because the function name passed to [initReactive](https://github.com/wuchalejs/wuchale/blob/5f347f4eba36966db16f0302514c3ec6e50303ea/packages/jsx/src/index.ts#L41-L48) is `""`.

This pr fixes this issue by passing the variable name as the function name, if the variable declaration is a arrow function (or function expression).
