### PR TITLE
Add zed settings for biome

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,25 @@
+{
+    "languages": {
+        "JavaScript": {
+            "formatter": { "language_server": { "name": "biome" } },
+            "code_actions_on_format": {
+                "source.fixAll.biome": true,
+                "source.organizeImports.biome": true
+            }
+        },
+        "TypeScript": {
+            "formatter": { "language_server": { "name": "biome" } },
+            "code_actions_on_format": {
+                "source.fixAll.biome": true,
+                "source.organizeImports.biome": true
+            }
+        },
+        "TSX": {
+            "formatter": { "language_server": { "name": "biome" } },
+            "code_actions_on_format": {
+                "source.fixAll.biome": true,
+                "source.organizeImports.biome": true
+            }
+        }
+    }
+}


### PR DESCRIPTION
When developing in this repo using zed, biome is not picked up because zed needs be told that it needs to use it (and you need to install the biome extension).

This pr adds the zed settings needed for biome to format the code, i think the lint issues should just work but i have not seen one yet, i could not find anything in the docs about needing to enable linting in the settings.